### PR TITLE
ビルドのフラグを掃除する

### DIFF
--- a/hexyll-core/hexyll-core.cabal
+++ b/hexyll-core/hexyll-core.cabal
@@ -60,20 +60,6 @@ Source-Repository head
   Type:     git
   Location: git://github.com/jaspervdj/hakyll.git
 
-Flag checkExternal
-  Description: Include external link checking
-  Default:     True
-
-Flag buildWebsite
-  Description: Build the hakyll website
-  Default:     False
-  Manual:      True
-
-Flag usePandoc
-  Description: Include Pandoc support
-  Default:     True
-  Manual:      True
-
 Library
   Ghc-Options:      -Wall
   Hs-Source-Dirs:   src
@@ -143,22 +129,6 @@ Library
     vector               >= 0.11     && < 0.13,
     yaml                 >= 0.8.11   && < 0.12
 
-  If flag(checkExternal)
-    Build-depends:
-      http-conduit >= 2.2    && < 2.4,
-      http-types   >= 0.7    && < 0.13
-    Cpp-options:
-      -DCHECK_EXTERNAL
-
-  If flag(usePandoc)
-    Exposed-Modules:
-    Other-Modules:
-    Build-Depends:
-      pandoc          >= 2.0.5    && < 2.8,
-      pandoc-citeproc >= 0.14     && < 0.17
-    Cpp-options:
-      -DUSE_PANDOC
-
 Test-suite hakyll-tests
   Type:             exitcode-stdio-1.0
   Hs-source-dirs:   tests
@@ -215,11 +185,3 @@ Test-suite hakyll-tests
     unordered-containers >= 0.2      && < 0.3,
     vector               >= 0.11     && < 0.13,
     yaml                 >= 0.8.11   && < 0.12
-
-  If flag(checkExternal)
-    Cpp-options:
-      -DCHECK_EXTERNAL
-
-  If flag(usePandoc)
-    Cpp-options:
-      -DUSE_PANDOC

--- a/hexyll-pandoc/hexyll-pandoc.cabal
+++ b/hexyll-pandoc/hexyll-pandoc.cabal
@@ -105,7 +105,7 @@ Library
     vector               >= 0.11     && < 0.13,
     yaml                 >= 0.8.11   && < 0.12,
     pandoc               >= 2.0.5    && < 2.8,
-    pandoc-citeproc      >= 0.14     && < 0.17
+    pandoc-citeproc      >= 0.14     && < 0.17,
     -- family
     hexyll-core,
     hexyll

--- a/hexyll-pandoc/hexyll-pandoc.cabal
+++ b/hexyll-pandoc/hexyll-pandoc.cabal
@@ -60,28 +60,18 @@ Source-Repository head
   Type:     git
   Location: git://github.com/jaspervdj/hakyll.git
 
-Flag checkExternal
-  Description: Include external link checking
-  Default:     True
-
-Flag buildWebsite
-  Description: Build the hakyll website
-  Default:     False
-  Manual:      True
-
-Flag usePandoc
-  Description: Include Pandoc support
-  Default:     True
-  Manual:      True
-
 Library
   Ghc-Options:      -Wall
   Hs-Source-Dirs:   src
   Default-language: Haskell2010
 
   Exposed-Modules:
+    Hexyll.Web.Pandoc
+    Hexyll.Web.Pandoc.Biblio
+    Hexyll.Web.Pandoc.FileType
 
   Other-Modules:
+    Hexyll.Web.Pandoc.Binary
 
   Build-Depends:
     base                 >= 4.8      && < 5,
@@ -114,29 +104,11 @@ Library
     unordered-containers >= 0.2      && < 0.3,
     vector               >= 0.11     && < 0.13,
     yaml                 >= 0.8.11   && < 0.12,
+    pandoc               >= 2.0.5    && < 2.8,
+    pandoc-citeproc      >= 0.14     && < 0.17
     -- family
     hexyll-core,
     hexyll
-
-  If flag(checkExternal)
-    Build-depends:
-      http-conduit >= 2.2    && < 2.4,
-      http-types   >= 0.7    && < 0.13
-    Cpp-options:
-      -DCHECK_EXTERNAL
-
-  If flag(usePandoc)
-    Exposed-Modules:
-      Hexyll.Web.Pandoc
-      Hexyll.Web.Pandoc.Biblio
-      Hexyll.Web.Pandoc.FileType
-    Other-Modules:
-      Hexyll.Web.Pandoc.Binary
-    Build-Depends:
-      pandoc          >= 2.0.5    && < 2.8,
-      pandoc-citeproc >= 0.14     && < 0.17
-    Cpp-options:
-      -DUSE_PANDOC
 
 Test-suite hakyll-tests
   Type:             exitcode-stdio-1.0
@@ -146,6 +118,7 @@ Test-suite hakyll-tests
   Default-language: Haskell2010
 
   Other-modules:
+    Hexyll.Web.Pandoc.FileType.Tests
     TestSuite.Util
 
   Build-Depends:
@@ -165,13 +138,3 @@ Test-suite hakyll-tests
     -- family
     hexyll-core,
     hexyll
-
-  If flag(checkExternal)
-    Cpp-options:
-      -DCHECK_EXTERNAL
-
-  If flag(usePandoc)
-    Other-modules:
-      Hexyll.Web.Pandoc.FileType.Tests
-    Cpp-options:
-      -DUSE_PANDOC

--- a/hexyll-pandoc/tests/TestSuite.hs
+++ b/hexyll-pandoc/tests/TestSuite.hs
@@ -10,9 +10,7 @@ import           Test.Tasty                           (defaultMain, testGroup)
 
 
 --------------------------------------------------------------------------------
-#ifdef USE_PANDOC
 import qualified Hexyll.Web.Pandoc.FileType.Tests
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-pandoc/tests/TestSuite.hs
+++ b/hexyll-pandoc/tests/TestSuite.hs
@@ -18,8 +18,5 @@ import qualified Hexyll.Web.Pandoc.FileType.Tests
 --------------------------------------------------------------------------------
 main :: IO ()
 main = defaultMain $ testGroup "Hexyll"
-    [
-#ifdef USE_PANDOC
-      Hexyll.Web.Pandoc.FileType.Tests.tests
-#endif
+    [ Hexyll.Web.Pandoc.FileType.Tests.tests
     ]

--- a/hexyll/hexyll.cabal
+++ b/hexyll/hexyll.cabal
@@ -64,16 +64,6 @@ Flag checkExternal
   Description: Include external link checking
   Default:     True
 
-Flag buildWebsite
-  Description: Build the hakyll website
-  Default:     False
-  Manual:      True
-
-Flag usePandoc
-  Description: Include Pandoc support
-  Default:     True
-  Manual:      True
-
 Library
   Ghc-Options:      -Wall
   Hs-Source-Dirs:   src
@@ -142,13 +132,6 @@ Library
     Cpp-options:
       -DCHECK_EXTERNAL
 
-  If flag(usePandoc)
-    Exposed-Modules:
-    Other-Modules:
-    Build-Depends:
-    Cpp-options:
-      -DUSE_PANDOC
-
 Test-suite hakyll-tests
   Type:             exitcode-stdio-1.0
   Hs-source-dirs:   tests
@@ -186,8 +169,3 @@ Test-suite hakyll-tests
   If flag(checkExternal)
     Cpp-options:
       -DCHECK_EXTERNAL
-
-  If flag(usePandoc)
-    Other-modules:
-    Cpp-options:
-      -DUSE_PANDOC

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,6 @@ save-hackage-creds: false
 flags:
   hexyll:
     checkExternal: true
-  hexyll-pandoc:
-    usePandoc: true
 
 packages:
 - 'hexyll-core'

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,6 @@ save-hackage-creds: false
 flags:
   hexyll:
     checkExternal: true
-    usePandoc:     true
-    buildWebsite:  true
   hexyll-pandoc:
     usePandoc: true
 


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/23 .

一つだけ checkExternal というフラグを残したが、これも何をやっているのか理解出来たら消したい。