### PR TITLE
cryptohash から cryptonite に移行する

### DIFF
--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -68,6 +68,7 @@ dependencies:
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
 - lrucache             >= 1.2.0.1  && < 1.3
+- memory               >= 0.14.18  && < 0.15
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -61,7 +61,7 @@ dependencies:
 - blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
-- cryptohash           >= 0.11.9   && < 0.12
+- cryptonite           >= 0.25     && < 0.26
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -16,7 +16,8 @@ module Hexyll.Core.Store
 
 
 --------------------------------------------------------------------------------
-import qualified Crypto.Hash.MD5      as MD5
+import qualified Data.ByteArray       as BA
+import qualified Crypto.Hash          as CH
 import           Data.Binary          (Binary, decode, encodeFile)
 import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as BL
@@ -203,4 +204,11 @@ hash = toHex . B.unpack . hashMD5 . T.encodeUtf8 . T.pack . intercalate "/"
 --------------------------------------------------------------------------------
 -- | Hash by MD5
 hashMD5 :: B.ByteString -> B.ByteString
-hashMD5 = MD5.hash
+hashMD5 x =
+  let
+    digest :: CH.Digest CH.MD5
+    digest = CH.hash x
+    bytes :: B.ByteString
+    bytes = BA.convert digest
+  in
+    bytes

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -193,8 +193,14 @@ deleteFile = (`catchIOError` \_ -> return ()) . removeFile
 --------------------------------------------------------------------------------
 -- | Mostly meant for internal usage
 hash :: [String] -> String
-hash = toHex . B.unpack . MD5.hash . T.encodeUtf8 . T.pack . intercalate "/"
+hash = toHex . B.unpack . hashMD5 . T.encodeUtf8 . T.pack . intercalate "/"
   where
     toHex [] = ""
     toHex (x : xs) | x < 16 = '0' : showHex x (toHex xs)
                    | otherwise = showHex x (toHex xs)
+
+
+--------------------------------------------------------------------------------
+-- | Hash by MD5
+hashMD5 :: B.ByteString -> B.ByteString
+hashMD5 = MD5.hash

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -61,7 +61,6 @@ dependencies:
 - blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
-- cryptohash           >= 0.11.9   && < 0.12
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -61,7 +61,6 @@ dependencies:
 - blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
-- cryptohash           >= 0.11.9   && < 0.12
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,3 +16,6 @@ nix:
 
 extra-deps:
 - 'lrucache-1.2.0.1'
+
+drop-packages:
+- 'cryptohash'


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/42 .

cryptohash から cryptonite に移行する。まず、 cryptohash は非推奨になっている。そして、移行先として指定されているパッケージが cryptonite である。

cryptonite はパッケージの書き方が抽象的でモダンな印象を受ける。良さそうだ。