### PR TITLE
古いライブラリに対応するためのコードを掃除する

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -43,9 +43,6 @@ import           Control.Monad                  (forM_)
 import           Control.Monad.Except           (MonadError (..))
 import           Data.List.NonEmpty             (NonEmpty (..))
 import qualified Data.List.NonEmpty             as NonEmpty
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup                 (Semigroup (..))
-#endif
 import           Data.Set                       (Set)
 import qualified Data.Set                       as S
 
@@ -96,7 +93,6 @@ data CompilerWrite = CompilerWrite
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup CompilerWrite where
     (<>) (CompilerWrite d1 h1) (CompilerWrite d2 h2) =
         CompilerWrite (d1 ++ d2) (h1 + h2)
@@ -104,12 +100,6 @@ instance Semigroup CompilerWrite where
 instance Monoid CompilerWrite where
     mempty  = CompilerWrite [] 0
     mappend = (<>)
-#else
-instance Monoid CompilerWrite where
-    mempty = CompilerWrite [] 0
-    mappend (CompilerWrite d1 h1) (CompilerWrite d2 h2) =
-        CompilerWrite (d1 ++ d2) (h1 + h2)
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -14,11 +14,7 @@ module Hexyll.Core.File
 --------------------------------------------------------------------------------
 import           Data.Binary                   (Binary (..))
 import           Data.Typeable                 (Typeable)
-#if MIN_VERSION_directory(1,2,6)
-import           System.Directory              (copyFileWithMetadata)
-#else
 import           System.Directory              (copyFile)
-#endif
 import           System.Directory              (doesFileExist,
                                                 renameFile)
 import           System.FilePath               ((</>))
@@ -44,11 +40,9 @@ newtype CopyFile = CopyFile FilePath
 
 --------------------------------------------------------------------------------
 instance Writable CopyFile where
-#if MIN_VERSION_directory(1,2,6)
-    write dst (Item _ (CopyFile src)) = copyFileWithMetadata src dst
-#else
     write dst (Item _ (CopyFile src)) = copyFile src dst
-#endif
+
+
 --------------------------------------------------------------------------------
 copyFileCompiler :: Compiler (Item CopyFile)
 copyFileCompiler = do

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -14,11 +14,7 @@ module Hexyll.Core.File
 --------------------------------------------------------------------------------
 import           Data.Binary                   (Binary (..))
 import           Data.Typeable                 (Typeable)
-#if MIN_VERSION_directory(1,2,6)
 import           System.Directory              (copyFileWithMetadata)
-#else
-import           System.Directory              (copyFile)
-#endif
 import           System.Directory              (doesFileExist,
                                                 renameFile)
 import           System.FilePath               ((</>))
@@ -44,11 +40,9 @@ newtype CopyFile = CopyFile FilePath
 
 --------------------------------------------------------------------------------
 instance Writable CopyFile where
-#if MIN_VERSION_directory(1,2,6)
     write dst (Item _ (CopyFile src)) = copyFileWithMetadata src dst
-#else
-    write dst (Item _ (CopyFile src)) = copyFile src dst
-#endif
+
+
 --------------------------------------------------------------------------------
 copyFileCompiler :: Compiler (Item CopyFile)
 copyFileCompiler = do

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -14,7 +14,11 @@ module Hexyll.Core.File
 --------------------------------------------------------------------------------
 import           Data.Binary                   (Binary (..))
 import           Data.Typeable                 (Typeable)
+#if MIN_VERSION_directory(1,2,6)
+import           System.Directory              (copyFileWithMetadata)
+#else
 import           System.Directory              (copyFile)
+#endif
 import           System.Directory              (doesFileExist,
                                                 renameFile)
 import           System.FilePath               ((</>))
@@ -40,9 +44,11 @@ newtype CopyFile = CopyFile FilePath
 
 --------------------------------------------------------------------------------
 instance Writable CopyFile where
+#if MIN_VERSION_directory(1,2,6)
+    write dst (Item _ (CopyFile src)) = copyFileWithMetadata src dst
+#else
     write dst (Item _ (CopyFile src)) = copyFile src dst
-
-
+#endif
 --------------------------------------------------------------------------------
 copyFileCompiler :: Compiler (Item CopyFile)
 copyFileCompiler = do

--- a/hexyll-core/src/Hexyll/Core/Identifier/Pattern/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/Pattern/Internal.hs
@@ -13,12 +13,6 @@ import           Data.Set               (Set)
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup         (Semigroup (..))
-#endif
-
-
---------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
 
 
@@ -78,15 +72,9 @@ instance Binary Pattern where
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Pattern where
     (<>) = And
 
 instance Monoid Pattern where
     mempty  = Everything
     mappend = (<>)
-#else
-instance Monoid Pattern where
-    mempty  = Everything
-    mappend = And
-#endif

--- a/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
@@ -36,11 +36,9 @@ import           System.FilePath        (addExtension, (</>))
 
 
 --------------------------------------------------------------------------------
-#if !MIN_VERSION_directory(1,2,0)
 import           Data.Time              (readTime)
 import           System.Locale          (defaultTimeLocale)
 import           System.Time            (formatCalendarTime, toCalendarTime)
-#endif
 
 
 --------------------------------------------------------------------------------
@@ -193,10 +191,6 @@ resourceModificationTime p i =
 --------------------------------------------------------------------------------
 fileModificationTime :: FilePath -> IO UTCTime
 fileModificationTime fp = do
-#if MIN_VERSION_directory(1,2,0)
-    getModificationTime fp
-#else
     ct <- toCalendarTime =<< getModificationTime fp
     let str = formatCalendarTime defaultTimeLocale "%s" ct
     return $ readTime defaultTimeLocale "%s" str
-#endif

--- a/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
@@ -36,9 +36,11 @@ import           System.FilePath        (addExtension, (</>))
 
 
 --------------------------------------------------------------------------------
+#if !MIN_VERSION_directory(1,2,0)
 import           Data.Time              (readTime)
 import           System.Locale          (defaultTimeLocale)
 import           System.Time            (formatCalendarTime, toCalendarTime)
+#endif
 
 
 --------------------------------------------------------------------------------
@@ -191,6 +193,10 @@ resourceModificationTime p i =
 --------------------------------------------------------------------------------
 fileModificationTime :: FilePath -> IO UTCTime
 fileModificationTime fp = do
+#if MIN_VERSION_directory(1,2,0)
+    getModificationTime fp
+#else
     ct <- toCalendarTime =<< getModificationTime fp
     let str = formatCalendarTime defaultTimeLocale "%s" ct
     return $ readTime defaultTimeLocale "%s" str
+#endif

--- a/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
@@ -36,14 +36,6 @@ import           System.FilePath        (addExtension, (</>))
 
 
 --------------------------------------------------------------------------------
-#if !MIN_VERSION_directory(1,2,0)
-import           Data.Time              (readTime)
-import           System.Locale          (defaultTimeLocale)
-import           System.Time            (formatCalendarTime, toCalendarTime)
-#endif
-
-
---------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Store      (Store)
 import qualified Hexyll.Core.Store      as Store
@@ -193,10 +185,4 @@ resourceModificationTime p i =
 --------------------------------------------------------------------------------
 fileModificationTime :: FilePath -> IO UTCTime
 fileModificationTime fp = do
-#if MIN_VERSION_directory(1,2,0)
     getModificationTime fp
-#else
-    ct <- toCalendarTime =<< getModificationTime fp
-    let str = formatCalendarTime defaultTimeLocale "%s" ct
-    return $ readTime defaultTimeLocale "%s" str
-#endif

--- a/hexyll-core/src/Hexyll/Core/Routes.hs
+++ b/hexyll-core/src/Hexyll/Core/Routes.hs
@@ -43,9 +43,6 @@ module Hexyll.Core.Routes
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup                 (Semigroup (..))
-#endif
 import           System.FilePath                (replaceExtension)
 
 
@@ -78,7 +75,6 @@ newtype Routes = Routes
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Routes where
     (<>) (Routes f) (Routes g) = Routes $ \p id' -> do
         (mfp, um) <- f p id'
@@ -89,15 +85,6 @@ instance Semigroup Routes where
 instance Monoid Routes where
     mempty  = Routes $ \_ _ -> return (Nothing, False)
     mappend = (<>)
-#else
-instance Monoid Routes where
-    mempty = Routes $ \_ _ -> return (Nothing, False)
-    mappend (Routes f) (Routes g) = Routes $ \p id' -> do
-        (mfp, um) <- f p id'
-        case mfp of
-            Nothing -> g p id'
-            Just _  -> return (mfp, um)
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
@@ -17,9 +17,6 @@ import           Control.Monad.Reader           (ask)
 import           Control.Monad.RWS              (RWST, runRWST)
 import           Control.Monad.Trans            (liftIO)
 import qualified Data.Map                       as M
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup                 (Semigroup (..))
-#endif
 import           Data.Set                       (Set)
 
 
@@ -56,7 +53,6 @@ data RuleSet = RuleSet
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup RuleSet where
     (<>) (RuleSet r1 c1 s1 p1) (RuleSet r2 c2 s2 p2) =
         RuleSet (mappend r1 r2) (mappend c1 c2) (mappend s1 s2) (p1 .||. p2)
@@ -64,12 +60,6 @@ instance Semigroup RuleSet where
 instance Monoid RuleSet where
     mempty  = RuleSet mempty mempty mempty mempty
     mappend = (<>)
-#else
-instance Monoid RuleSet where
-    mempty = RuleSet mempty mempty mempty mempty
-    mappend (RuleSet r1 c1 s1 p1) (RuleSet r2 c2 s2 p2) =
-        RuleSet (mappend r1 r2) (mappend c1 c2) (mappend s1 s2) (p1 .||. p2)
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Check.hs
+++ b/hexyll/src/Hexyll/Check.hs
@@ -19,9 +19,6 @@ import           Control.Monad.Trans          (liftIO)
 import           Control.Monad.Trans.Resource (runResourceT)
 import           Data.List                    (isPrefixOf)
 import qualified Data.Map.Lazy                as Map
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup               (Semigroup (..))
-#endif
 import           Network.URI                  (unEscapeString)
 import           System.Directory             (doesDirectoryExist,
                                                doesFileExist)
@@ -88,7 +85,6 @@ data CheckerWrite = CheckerWrite
 
 
 --------------------------------------------------------------------------------
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup CheckerWrite where
     (<>) (CheckerWrite f1 o1) (CheckerWrite f2 o2) =
         CheckerWrite (f1 + f2) (o1 + o2)
@@ -96,12 +92,6 @@ instance Semigroup CheckerWrite where
 instance Monoid CheckerWrite where
     mempty  = CheckerWrite 0 0
     mappend = (<>)
-#else
-instance Monoid CheckerWrite where
-    mempty                                            = CheckerWrite 0 0
-    mappend (CheckerWrite f1 o1) (CheckerWrite f2 o2) =
-        CheckerWrite (f1 + f2) (o1 + o2)
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Web/Template/Context.hs
+++ b/hexyll/src/Hexyll/Web/Template/Context.hs
@@ -451,8 +451,4 @@ missingField = Context $ \k _ _ -> noResult $
     "Missing field '" ++ k ++ "' in context"
 
 parseTimeM :: Bool -> TimeLocale -> String -> String -> Maybe UTCTime
-#if MIN_VERSION_time(1,5,0)
 parseTimeM = TF.parseTimeM
-#else
-parseTimeM _ = TF.parseTime
-#endif

--- a/hexyll/src/Hexyll/Web/Template/Context.hs
+++ b/hexyll/src/Hexyll/Web/Template/Context.hs
@@ -31,7 +31,6 @@ module Hexyll.Web.Template.Context
     , listFieldWith
     , functionField
     , mapContext
-
     , defaultContext
     , bodyField
     , metadataField
@@ -55,9 +54,6 @@ module Hexyll.Web.Template.Context
 import           Control.Applicative           (Alternative (..))
 import           Control.Monad                 (msum)
 import           Data.List                     (intercalate, tails)
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup                (Semigroup (..))
-#endif
 import           Data.Time.Clock               (UTCTime (..))
 import           Data.Time.Format              (formatTime)
 import qualified Data.Time.Format              as TF
@@ -106,18 +102,12 @@ newtype Context a = Context
 --------------------------------------------------------------------------------
 -- | Tries to find a key in the left context,
 -- or when that fails in the right context.
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup (Context a) where
     (<>) (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
 
 instance Monoid (Context a) where
     mempty  = missingField
     mappend = (<>)
-#else
-instance Monoid (Context a) where
-    mempty                          = missingField
-    mappend (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
-#endif
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Web/Template/Context.hs
+++ b/hexyll/src/Hexyll/Web/Template/Context.hs
@@ -55,9 +55,6 @@ module Hexyll.Web.Template.Context
 import           Control.Applicative           (Alternative (..))
 import           Control.Monad                 (msum)
 import           Data.List                     (intercalate, tails)
-#if MIN_VERSION_base(4,9,0)
-import           Data.Semigroup                (Semigroup (..))
-#endif
 import           Data.Time.Clock               (UTCTime (..))
 import           Data.Time.Format              (formatTime)
 import qualified Data.Time.Format              as TF
@@ -106,18 +103,12 @@ newtype Context a = Context
 --------------------------------------------------------------------------------
 -- | Tries to find a key in the left context,
 -- or when that fails in the right context.
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup (Context a) where
     (<>) (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
 
 instance Monoid (Context a) where
     mempty  = missingField
     mappend = (<>)
-#else
-instance Monoid (Context a) where
-    mempty                          = missingField
-    mappend (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
-#endif
 
 
 --------------------------------------------------------------------------------
@@ -461,8 +452,4 @@ missingField = Context $ \k _ _ -> noResult $
     "Missing field '" ++ k ++ "' in context"
 
 parseTimeM :: Bool -> TimeLocale -> String -> String -> Maybe UTCTime
-#if MIN_VERSION_time(1,5,0)
-parseTimeM = TF.parseTimeM
-#else
-parseTimeM _ = TF.parseTime
-#endif
+parseTimeM _ = TF.parseTimeM

--- a/hexyll/src/Hexyll/Web/Template/Context.hs
+++ b/hexyll/src/Hexyll/Web/Template/Context.hs
@@ -55,6 +55,9 @@ module Hexyll.Web.Template.Context
 import           Control.Applicative           (Alternative (..))
 import           Control.Monad                 (msum)
 import           Data.List                     (intercalate, tails)
+#if MIN_VERSION_base(4,9,0)
+import           Data.Semigroup                (Semigroup (..))
+#endif
 import           Data.Time.Clock               (UTCTime (..))
 import           Data.Time.Format              (formatTime)
 import qualified Data.Time.Format              as TF
@@ -103,12 +106,18 @@ newtype Context a = Context
 --------------------------------------------------------------------------------
 -- | Tries to find a key in the left context,
 -- or when that fails in the right context.
+#if MIN_VERSION_base(4,9,0)
 instance Semigroup (Context a) where
     (<>) (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
 
 instance Monoid (Context a) where
     mempty  = missingField
     mappend = (<>)
+#else
+instance Monoid (Context a) where
+    mempty                          = missingField
+    mappend (Context f) (Context g) = Context $ \k a i -> f k a i <|> g k a i
+#endif
 
 
 --------------------------------------------------------------------------------
@@ -452,4 +461,8 @@ missingField = Context $ \k _ _ -> noResult $
     "Missing field '" ++ k ++ "' in context"
 
 parseTimeM :: Bool -> TimeLocale -> String -> String -> Maybe UTCTime
-parseTimeM _ = TF.parseTimeM
+#if MIN_VERSION_time(1,5,0)
+parseTimeM = TF.parseTimeM
+#else
+parseTimeM _ = TF.parseTime
+#endif


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/14 .

古いライブラリに対応するためのコードを掃除する。基本的に、もうサポートを切ったバージョンのための CPP による分岐が多い。