### PR TITLE
不要な依存パッケージの指定を削除する

### DIFF
--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -54,7 +54,6 @@ dependencies:
 - process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
-- resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -55,7 +55,6 @@ dependencies:
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
-- template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -57,7 +57,6 @@ dependencies:
 - scientific           >= 0.3.6.2  && < 0.4
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
-- time-locale-compat   >= 0.1.1.5  && < 0.2
 - unordered-containers >= 0.2.9.0  && < 0.3
 - vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -46,7 +46,6 @@ dependencies:
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
-- file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
 - lrucache             >= 1.2.0.1  && < 1.3
 - memory               >= 0.14.18  && < 0.15

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -55,7 +55,6 @@ dependencies:
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
-- tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
-- blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
 - cryptonite           >= 0.25     && < 0.26

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -50,7 +50,6 @@ dependencies:
 - lrucache             >= 1.2.0.1  && < 1.3
 - memory               >= 0.14.18  && < 0.15
 - mtl                  >= 2.2.2    && < 2.3
-- network-uri          >= 2.6.1.0  && < 2.7
 - parsec               >= 3.1.13.0 && < 3.2
 - process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2

--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -53,7 +53,6 @@ dependencies:
 - memory               >= 0.14.18  && < 0.15
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
-- optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
 - process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -52,7 +52,6 @@ dependencies:
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
 - parsec               >= 3.1.13.0 && < 3.2
-- process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
 - text                 >= 1.2.3.1  && < 1.3
-- time-locale-compat   >= 0.1.1.5  && < 0.2
 - unordered-containers >= 0.2.9.0  && < 0.3
 - vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
 - text                 >= 1.2.3.1  && < 1.3
-- yaml                 >= 0.8.32   && < 0.12
 - pandoc               >= 2.2.1    && < 2.6
 - pandoc-citeproc      >= 0.14.8.1 && < 0.16
 - hexyll-core          == 0.1.0.*

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
 - lrucache             >= 1.2.0.1  && < 1.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
 - lrucache             >= 1.2.0.1  && < 1.3
 - mtl                  >= 2.2.2    && < 2.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -68,7 +68,6 @@ dependencies:
 - pandoc               >= 2.2.1    && < 2.6
 - pandoc-citeproc      >= 0.14.8.1 && < 0.16
 - hexyll-core          == 0.1.0.*
-- hexyll               == 0.1.0.*
 
 library:
   source-dirs: src

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- network-uri          >= 2.6.1.0  && < 2.7
 - parsec               >= 3.1.13.0 && < 3.2
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- parsec               >= 3.1.13.0 && < 3.2
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
 - parsec               >= 3.1.13.0 && < 3.2
 - random               >= 1.1      && < 1.2

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- lrucache             >= 1.2.0.1  && < 1.3
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
 - parsec               >= 3.1.13.0 && < 3.2

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
 - text                 >= 1.2.3.1  && < 1.3
-- time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2
 - unordered-containers >= 0.2.9.0  && < 0.3
 - vector               >= 0.12.0.2 && < 0.13

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -51,7 +51,6 @@ dependencies:
 - lrucache             >= 1.2.0.1  && < 1.3
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
-- optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
 - process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
 - text                 >= 1.2.3.1  && < 1.3
-- unordered-containers >= 0.2.9.0  && < 0.3
 - vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12
 - pandoc               >= 2.2.1    && < 2.6

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
-- random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,8 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- blaze-html           >= 0.9.1.1  && < 0.10
-- blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
 - data-default         >= 0.7.1.1  && < 0.8

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - filepath             >= 1.4.2    && < 1.5
 - text                 >= 1.2.3.1  && < 1.3
-- vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12
 - pandoc               >= 2.2.1    && < 2.6
 - pandoc-citeproc      >= 0.14.8.1 && < 0.16

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -39,7 +39,6 @@ extra-source-files:
 dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
-- containers           >= 0.5.11.0 && < 0.7
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
@@ -95,6 +94,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hexyll-pandoc
+    - containers       >= 0.5.11.0 && < 0.7
     - QuickCheck       >= 2.11.3   && < 2.13
     - tasty            >= 1.1.0.4  && < 1.3
     - tasty-hunit      >= 0.10.0.1 && < 0.11

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -47,7 +47,6 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
-- scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -52,7 +52,6 @@ dependencies:
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2
-- unordered-containers >= 0.2.9.0  && < 0.3
 - vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12
 - hexyll-core          == 0.1.0.*

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
-- blaze-markup         >= 0.8.2.2  && < 0.9
 - bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
 - data-default         >= 0.7.1.1  && < 0.8

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -52,7 +52,6 @@ dependencies:
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2
-- yaml                 >= 0.8.32   && < 0.12
 - hexyll-core          == 0.1.0.*
 
 flags:

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -47,7 +47,6 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
-- resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
@@ -82,6 +81,7 @@ library:
   - condition: flag(checkExternal)
     dependencies:
     - directory    >= 1.3.1.5 && < 1.4
+    - resourcet    >= 1.2.2   && < 1.3
     - http-conduit >= 2.3.1   && < 2.4
     - http-types   >= 0.12.2  && < 0.13
     cpp-options:

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -40,7 +40,6 @@ dependencies:
 - base                 >= 4.11.1.0 && < 4.13
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
-- bytestring           >= 0.10.8.2 && < 0.11
 - containers           >= 0.5.11.0 && < 0.7
 - data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
@@ -110,6 +109,7 @@ tests:
     #- -with-rtsopts=-N
     dependencies:
     - hexyll
+    - bytestring       >= 0.10.8.2 && < 0.11
     - QuickCheck       >= 2.11.3   && < 2.13
     - tasty            >= 1.1.0.4  && < 1.3
     - tasty-hunit      >= 0.10.0.1 && < 0.11

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
 - containers           >= 0.5.11.0 && < 0.7
-- deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -52,7 +52,6 @@ dependencies:
 - text                 >= 1.2.3.1  && < 1.3
 - time                 >= 1.8.0.2  && < 1.9
 - time-locale-compat   >= 0.1.1.5  && < 0.2
-- vector               >= 0.12.0.2 && < 0.13
 - yaml                 >= 0.8.32   && < 0.12
 - hexyll-core          == 0.1.0.*
 

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -77,9 +77,9 @@ library:
   - condition: flag(checkExternal)
     dependencies:
     - directory    >= 1.3.1.5 && < 1.4
-    - resourcet    >= 1.2.2   && < 1.3
     - http-conduit >= 2.3.1   && < 2.4
     - http-types   >= 0.12.2  && < 0.13
+    - resourcet    >= 1.2.2   && < 1.3
     cpp-options:
     - -DCHECK_EXTERNAL
 

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
 - containers           >= 0.5.11.0 && < 0.7
-- directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
 - lrucache             >= 1.2.0.1  && < 1.3
@@ -85,8 +84,9 @@ library:
   when:
   - condition: flag(checkExternal)
     dependencies:
-    - http-conduit >= 2.3.1  && < 2.4
-    - http-types   >= 0.12.2 && < 0.13
+    - directory    >= 1.3.1.5 && < 1.4
+    - http-conduit >= 2.3.1   && < 2.4
+    - http-types   >= 0.12.2  && < 0.13
     cpp-options:
     - -DCHECK_EXTERNAL
 

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -53,7 +53,6 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
-- process              >= 1.6.3.0  && < 1.7
 - random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 - binary               >= 0.8.5.1  && < 0.9
 - blaze-html           >= 0.9.1.1  && < 0.10
 - containers           >= 0.5.11.0 && < 0.7
-- data-default         >= 0.7.1.1  && < 0.8
 - deepseq              >= 1.4.3.0  && < 1.5
 - directory            >= 1.3.1.5  && < 1.4
 - file-embed           >= 0.0.10.1 && < 0.1

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -47,7 +47,6 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
-- random               >= 1.1      && < 1.2
 - regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -43,7 +43,6 @@ dependencies:
 - containers           >= 0.5.11.0 && < 0.7
 - file-embed           >= 0.0.10.1 && < 0.1
 - filepath             >= 1.4.2    && < 1.5
-- lrucache             >= 1.2.0.1  && < 1.3
 - mtl                  >= 2.2.2    && < 2.3
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -47,7 +47,6 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
-- regex-tdfa           >= 1.2.3.1  && < 1.3
 - resourcet            >= 1.2.2    && < 1.3
 - scientific           >= 0.3.6.2  && < 0.4
 - tagsoup              >= 0.14.7   && < 0.15


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/52 .

不要な依存パッケージの指定を削除する。言い換えると刈り込む。いろいろ不要な依存パッケージの指定があった。