### PR TITLE
Hexyll.Core.Configuration をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -80,16 +80,16 @@ module Hexyll.Core.Configuration
   -- Default values:
   --
   -- >>> destinationDirectory defaultConfiguration
-  -- "_site"
+  -- "_site/"
   --
   -- >>> storeDirectory defaultConfiguration
-  -- "_cache"
+  -- "_cache/"
   --
   -- >>> tmpDirectory defaultConfiguration
-  -- "_cache/tmp"
+  -- "_cache/tmp/"
   --
   -- >>> providerDirectory defaultConfiguration
-  -- "."
+  -- "./"
   --
   -- >>> deployCommand defaultConfiguration
   -- "echo 'No deploy command specified' && exit 1"
@@ -119,33 +119,25 @@ module Hexyll.Core.Configuration
   -- * Files ending with a @~@.
   -- * Files ending with @.swp@.
   --
-  -- >>> defaultIgnoreFile ".gitignore"
+  -- >>> defaultIgnoreFile <$> parseRelFile ".gitignore"
   -- True
   --
-  -- >>> defaultIgnoreFile "Configuration.hs.swp"
+  -- >>> defaultIgnoreFile <$> parseRelFile "Configuration.hs.swp"
   -- True
   --
-  -- >>> defaultIgnoreFile "foo~"
+  -- >>> defaultIgnoreFile <$> parseRelFile "foo~"
   -- True
   --
-  -- >>> defaultIgnoreFile "#Main.hs#"
+  -- >>> defaultIgnoreFile <$> parseRelFile "#Main.hs#"
   -- True
   --
-  -- >>> defaultIgnoreFile "a.txt"
+  -- >>> defaultIgnoreFile <$> parseRelFile "a.txt"
   -- False
   --
-  -- >>> defaultIgnoreFile ".dot/ma.x"
+  -- >>> defaultIgnoreFile <$> parseRelFile ".dot/ma.x"
   -- False
   --
-  -- >>> defaultIgnoreFile "foo"
-  -- False
-  --
-  -- Note that 'defaultIgnoreFile' applied a directory path, returns @False@.
-  --
-  -- >>> defaultIgnoreFile "foo~/"
-  -- False
-  --
-  -- >>> defaultIgnoreFile ".p/"
+  -- >>> defaultIgnoreFile <$> parseRelFile "foo"
   -- False
   --
   -- @since 0.1.0.0

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -105,10 +105,10 @@ module Hexyll.Core.Configuration
   -- @since 0.1.0.0
   defaultConfiguration :: Configuration
   defaultConfiguration = Configuration
-    { destinationDirectory = $(parseRelDir "_site")
-    , storeDirectory       = $(parseRelDir "_cache")
-    , tmpDirectory         = $(parseRelDir "_cache/tmp")
-    , providerDirectory    = $(parseRelDir ".")
+    { destinationDirectory = $(mkRelDir "_site")
+    , storeDirectory       = $(mkRelDir "_cache")
+    , tmpDirectory         = $(mkRelDir "_cache/tmp")
+    , providerDirectory    = $(mkRelDir ".")
     , ignoreFile           = defaultIgnoreFile
     , deployCommand        = "echo 'No deploy command specified' && exit 1"
     , deploySite           = system . deployCommand

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- |
 -- Module:      Hexyll.Core.Configuration
 -- Copyright:   (c) 2019 Hexirp
@@ -103,10 +105,10 @@ module Hexyll.Core.Configuration
   -- @since 0.1.0.0
   defaultConfiguration :: Configuration
   defaultConfiguration = Configuration
-    { destinationDirectory = "_site"
-    , storeDirectory       = "_cache"
-    , tmpDirectory         = "_cache/tmp"
-    , providerDirectory    = "."
+    { destinationDirectory = $(parseRelDir "_site")
+    , storeDirectory       = $(parseRelDir "_cache")
+    , tmpDirectory         = $(parseRelDir "_cache/tmp")
+    , providerDirectory    = $(parseRelDir ".")
     , ignoreFile           = defaultIgnoreFile
     , deployCommand        = "echo 'No deploy command specified' && exit 1"
     , deploySite           = system . deployCommand

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -154,7 +154,7 @@ module Hexyll.Core.Configuration
   -- False
   --
   -- @since 0.1.0.0
-  defaultIgnoreFile :: FilePath -> Bool
+  defaultIgnoreFile :: Path Rel File -> Bool
   defaultIgnoreFile path
       | "."    `isPrefixOf` fileName = True
       | "#"    `isPrefixOf` fileName = True
@@ -162,7 +162,7 @@ module Hexyll.Core.Configuration
       | ".swp" `isSuffixOf` fileName = True
       | otherwise                    = False
     where
-      fileName = takeFileName path
+      fileName = toFilePath $ filename path
 
   -- | Check if a file should be ignored.
   --

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -18,13 +18,8 @@ module Hexyll.Core.Configuration
 
   import Prelude
 
-  import Control.Monad.Hexyll (orM)
-
   import Data.List    (isPrefixOf, isSuffixOf)
   import Data.Default (Default (..))
-
-  import System.FilePath         (normalise, takeFileName)
-  import System.Directory.Hexyll (inDir)
 
   import Path
 

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -24,6 +24,8 @@ module Hexyll.Core.Configuration
   import System.FilePath         (normalise, takeFileName)
   import System.Directory.Hexyll (inDir)
 
+  import Path
+
   import System.Exit    (ExitCode)
   import System.Process (system)
 
@@ -49,15 +51,15 @@ module Hexyll.Core.Configuration
   -- @since 0.1.0.0
   data Configuration = Configuration
     { -- | Directory in which the output written.
-      destinationDirectory :: FilePath
+      destinationDirectory :: Path Rel Dir
     , -- | Directory where hexyll's internal store is kept.
-      storeDirectory       :: FilePath
+      storeDirectory       :: Path Rel Dir
     , -- | Directory in which some temporary files will be kept.
-      tmpDirectory         :: FilePath
+      tmpDirectory         :: Path Rel Dir
     , -- | Directory where hexyll finds the files to compile.
-      providerDirectory    :: FilePath
+      providerDirectory    :: Path Rel Dir
     , -- | Function to determine ignored files.
-      ignoreFile           :: FilePath -> Bool
+      ignoreFile           :: Path Rel File -> Bool
     , -- | System command to upload/deploy your site.
       deployCommand        :: String
     , -- | Function to deploy the site from Haskell.

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -171,10 +171,10 @@ module Hexyll.Core.Configuration
   -- 'shouldIgnoreFile' will consider the condition.
   --
   -- @since 0.1.0.0
-  shouldIgnoreFile :: Configuration -> FilePath -> IO Bool
-  shouldIgnoreFile conf path = orM
-    [ inDir path $ destinationDirectory conf
-    , inDir path $ storeDirectory conf
-    , inDir path $ tmpDirectory conf
-    , return $ ignoreFile conf $ normalise path
+  shouldIgnoreFile :: Configuration -> Path Rel File -> IO Bool
+  shouldIgnoreFile conf path = return $ or
+    [ destinationDirectory conf `isProperPrefixOf` path
+    , storeDirectory conf `isProperPrefixOf` path
+    , tmpDirectory conf `isProperPrefixOf` path
+    , ignoreFile conf path
     ]

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -84,6 +84,6 @@ newTmpFile suffix = do
     mkPath = do
         rand <- compilerUnsafeIO $ randomIO :: Compiler Int
         tmp  <- toFilePath . tmpDirectory . compilerConfig <$> compilerAsk
-        let path = tmp </> Store.hash [show rand] ++ "-" ++ suffix
+        let path = tmp ++ Store.hash [show rand] ++ "-" ++ suffix
         exists <- compilerUnsafeIO $ doesFileExist path
         if exists then mkPath else return path

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -19,7 +19,6 @@ import           Data.Typeable                 (Typeable)
 import           System.Directory              (copyFileWithMetadata)
 import           System.Directory              (doesFileExist,
                                                 renameFile)
-import           System.FilePath               ((</>))
 import           System.Random                 (randomIO)
 
 

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -10,6 +10,8 @@ module Hexyll.Core.File
     , newTmpFile
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import           Data.Binary                   (Binary (..))
@@ -81,7 +83,7 @@ newTmpFile suffix = do
   where
     mkPath = do
         rand <- compilerUnsafeIO $ randomIO :: Compiler Int
-        tmp  <- tmpDirectory . compilerConfig <$> compilerAsk
+        tmp  <- toFilePath . tmpDirectory . compilerConfig <$> compilerAsk
         let path = tmp </> Store.hash [show rand] ++ "-" ++ suffix
         exists <- compilerUnsafeIO $ doesFileExist path
         if exists then mkPath else return path

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -45,10 +45,10 @@ run config logger rules = do
     -- Initialization
     Logger.header logger "Initialising..."
     Logger.message logger "Creating store..."
-    store <- Store.new (inMemoryCache config) $ storeDirectory config
+    store <- Store.new (inMemoryCache config) $ toFilePath $ storeDirectory config
     Logger.message logger "Creating provider..."
-    provider <- newProvider store (shouldIgnoreFile config) $
-        providerDirectory config
+    provider <- newProvider store (parseRelFile >=> shouldIgnoreFile config) $
+        toFilePath $ providerDirectory config
     Logger.message logger "Running rules..."
     ruleSet  <- runRules rules provider
 
@@ -86,7 +86,7 @@ run config logger rules = do
             Store.set store factsKey $ runtimeFacts s
 
             Logger.debug logger "Removing tmp directory..."
-            removeDirectory $ tmpDirectory config
+            removeDirectory $ toFilePath $ tmpDirectory config
 
             Logger.flush logger
             return (ExitSuccess, ruleSet)
@@ -234,7 +234,7 @@ chase trail id'
                 case mroute of
                     Nothing    -> return ()
                     Just route -> do
-                        let path = destinationDirectory config </> route
+                        let path = (toFilePath . destinationDirectory) config ++ route
                         liftIO $ makeDirectories path
                         liftIO $ write path item
                         Logger.debug logger $ "Routed to " ++ path

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -27,7 +27,7 @@ import           Hexyll.Core.Compiler.Internal
 import           Hexyll.Core.Compiler.Require
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Dependencies
-import           Hexyll.Core.Identifier
+import           Hexyll.Core.Identifier hiding (toFilePath)
 import           Hexyll.Core.Item
 import           Hexyll.Core.Item.SomeItem
 import           Hexyll.Core.Logger            (Logger)

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -3,9 +3,11 @@ module Hexyll.Core.Runtime
     ( run
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
-import           Control.Monad                 (unless)
+import           Control.Monad                 (unless, (>=>))
 import           Control.Monad.Except          (ExceptT, runExceptT, throwError)
 import           Control.Monad.Reader          (ask)
 import           Control.Monad.RWS             (RWST, runRWST)

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -19,7 +19,6 @@ import qualified Data.Map                      as M
 import           Data.Set                      (Set)
 import qualified Data.Set                      as S
 import           System.Exit                   (ExitCode (..))
-import           System.FilePath               ((</>))
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/test/Hexyll/Core/ConfigurationSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/ConfigurationSpec.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Hexyll.Core.ConfigurationSpec (spec) where
 
   import Prelude
   import Test.Hspec
+
+  import Path
 
   import Hexyll.Core.Configuration
 
@@ -10,53 +14,38 @@ module Hexyll.Core.ConfigurationSpec (spec) where
 
     describe "defaultIgnoreFile" $ do
 
-      it "ignore files is prefix of '.' ('.')" $ do
-        defaultIgnoreFile "." `shouldBe` True
-
-      it "ignore files is prefix of '.' ('..')" $ do
-        defaultIgnoreFile ".." `shouldBe` True
-
       it "ignore files is prefix of '.' ('.gitignore')" $ do
-        defaultIgnoreFile ".gitignore" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile ".gitignore") `shouldBe` True
 
       it "ignore files is prefix of '#' ('#Main.hs#')" $ do
-        defaultIgnoreFile "#Main.hs#" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "#Main.hs#") `shouldBe` True
 
       it "ignore files is prefix of '#' ('#s')" $ do
-        defaultIgnoreFile "#s" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "#s") `shouldBe` True
 
       it "ignore files is prefix of '#' ('#')" $ do
-        defaultIgnoreFile "#" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "#") `shouldBe` True
 
       it "ignore files is suffix of '~' ('~foo')" $ do
-        defaultIgnoreFile "foo~" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "foo~") `shouldBe` True
 
       it "ignore files is suffix of '~' ('pya/~')" $ do
-        defaultIgnoreFile "pya/~" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "pya/~") `shouldBe` True
 
       it "ignore files is suffix of '~' ('mu/herobrine~')" $ do
-        defaultIgnoreFile "mu/herobrine~" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "mu/herobrine~") `shouldBe` True
 
       it "ignore files is suffix of '.swp'" $ do
-        defaultIgnoreFile "a.txt.swp" `shouldBe` True
+        defaultIgnoreFile $(mkRelFile "a.txt.swp") `shouldBe` True
 
       it "do not ignore other files ('ma.')" $ do
-        defaultIgnoreFile "ma." `shouldBe` False
+        defaultIgnoreFile $(mkRelFile "ma.") `shouldBe` False
 
       it "do not ignore other files ('hash#')" $ do
-        defaultIgnoreFile "hash#" `shouldBe` False
+        defaultIgnoreFile $(mkRelFile "hash#") `shouldBe` False
 
       it "do not ignore other files ('~foo')" $ do
-        defaultIgnoreFile "~foo" `shouldBe` False
+        defaultIgnoreFile $(mkRelFile "~foo") `shouldBe` False
 
       it "do not ignore other files ('a.yxy.swp.log')" $ do
-        defaultIgnoreFile "a.yxy.swp.log" `shouldBe` False
-
-      it "applied to a directory, returns False ('eee/')" $ do
-        defaultIgnoreFile "eee/" `shouldBe` False
-
-      it "applied to a directory, returns False ('too/eee/')" $ do
-        defaultIgnoreFile "too/eee/" `shouldBe` False
-
-      it "applied to a directory, returns False ('foo~/')" $ do
-        defaultIgnoreFile "foo~/" `shouldBe` False
+        defaultIgnoreFile $(mkRelFile "a.yxy.swp.log") `shouldBe` False

--- a/hexyll-pandoc/package.yaml
+++ b/hexyll-pandoc/package.yaml
@@ -72,6 +72,7 @@ tests:
     dependencies:
     - hexyll-pandoc
     - containers       >= 0.5.11.0 && < 0.7
+    - path             >= 0.6.1    && < 0.7
     - QuickCheck       >= 2.11.3   && < 2.13
     - tasty            >= 1.1.0.4  && < 1.3
     - tasty-hunit      >= 0.10.0.1 && < 0.11

--- a/hexyll-pandoc/test/TestSuite/Util.hs
+++ b/hexyll-pandoc/test/TestSuite/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 --------------------------------------------------------------------------------
 -- | Test utilities
 module TestSuite.Util

--- a/hexyll-pandoc/test/TestSuite/Util.hs
+++ b/hexyll-pandoc/test/TestSuite/Util.hs
@@ -12,6 +12,8 @@ module TestSuite.Util
     , renderParagraphs
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import           Data.List                     (intercalate, isInfixOf)
@@ -25,7 +27,7 @@ import           Text.Printf                   (printf)
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Compiler.Internal
 import           Hexyll.Core.Configuration
-import           Hexyll.Core.Identifier
+import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
 import           Hexyll.Core.Store             (Store)
@@ -44,13 +46,13 @@ fromAssertions name =
 
 --------------------------------------------------------------------------------
 newTestStore :: IO Store
-newTestStore = Store.new True $ storeDirectory testConfiguration
+newTestStore = Store.new True $ toFilePath $ storeDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------
 newTestProvider :: Store -> IO Provider
 newTestProvider store = newProvider store (const $ return False) $
-    providerDirectory testConfiguration
+    toFilePath $ providerDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------
@@ -100,19 +102,19 @@ testCompilerError store provider underlying compiler expectedMessage = do
 --------------------------------------------------------------------------------
 testConfiguration :: Configuration
 testConfiguration = defaultConfiguration
-    { destinationDirectory = "_testsite"
-    , storeDirectory       = "_teststore"
-    , tmpDirectory         = "_testtmp"
-    , providerDirectory    = "test/data"
+    { destinationDirectory = $(mkRelDir "_testsite")
+    , storeDirectory       = $(mkRelDir "_teststore")
+    , tmpDirectory         = $(mkRelDir "_testtmp")
+    , providerDirectory    = $(mkRelDir "test/data")
     }
 
 
 --------------------------------------------------------------------------------
 cleanTestEnv :: IO ()
 cleanTestEnv = do
-    removeDirectory $ destinationDirectory testConfiguration
-    removeDirectory $ storeDirectory testConfiguration
-    removeDirectory $ tmpDirectory testConfiguration
+    removeDirectory $ toFilePath $ destinationDirectory testConfiguration
+    removeDirectory $ toFilePath $ storeDirectory testConfiguration
+    removeDirectory $ toFilePath $ tmpDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/package.yaml
+++ b/hexyll/package.yaml
@@ -47,6 +47,7 @@ dependencies:
 - network-uri          >= 2.6.1.0  && < 2.7
 - optparse-applicative >= 0.14.3.0 && < 0.15
 - parsec               >= 3.1.13.0 && < 3.2
+- path                 >= 0.6.1    && < 0.7
 - tagsoup              >= 0.14.7   && < 0.15
 - template-haskell     >= 2.13.0.0 && < 2.15
 - text                 >= 1.2.3.1  && < 1.3

--- a/hexyll/src/Hexyll/Check.hs
+++ b/hexyll/src/Hexyll/Check.hs
@@ -7,7 +7,7 @@ module Hexyll.Check
     ) where
 
 import Prelude
-import Path
+import Path hiding ((</>))
 
 --------------------------------------------------------------------------------
 import           Control.Concurrent.MVar      (MVar, newEmptyMVar, putMVar,

--- a/hexyll/src/Hexyll/Check.hs
+++ b/hexyll/src/Hexyll/Check.hs
@@ -6,6 +6,8 @@ module Hexyll.Check
     , check
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import           Control.Concurrent.MVar      (MVar, newEmptyMVar, putMVar,
@@ -124,10 +126,10 @@ checkDestination :: Checker ()
 checkDestination = do
     config <- checkerConfig <$> ask
     files  <- liftIO $ getRecursiveContents
-        (const $ return False) (destinationDirectory config)
+        (const $ return False) (toFilePath $ destinationDirectory config)
 
     let htmls =
-            [ destinationDirectory config </> file
+            [ (toFilePath . destinationDirectory) config ++ file
             | file <- files
             , takeExtension file == ".html"
             ]
@@ -222,7 +224,7 @@ checkInternalUrl base url = case url' of
     "" -> ok url
     _  -> do
         config <- checkerConfig <$> ask
-        let dest = destinationDirectory config
+        let dest = toFilePath $ destinationDirectory config
             dir  = takeDirectory base
             filePath
                 | "/" `isPrefixOf` url' = dest ++ url'

--- a/hexyll/src/Hexyll/Commands.hs
+++ b/hexyll/src/Hexyll/Commands.hs
@@ -10,6 +10,8 @@ module Hexyll.Commands
     , deploy
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import           System.Exit                (ExitCode)
@@ -42,9 +44,9 @@ check = Check.check
 -- | Remove the output directories
 clean :: Configuration -> Logger -> IO ()
 clean conf logger = do
-    remove $ destinationDirectory conf
-    remove $ storeDirectory conf
-    remove $ tmpDirectory conf
+    remove $ toFilePath $ destinationDirectory conf
+    remove $ toFilePath $ storeDirectory conf
+    remove $ toFilePath $ tmpDirectory conf
   where
     remove dir = do
         Logger.header logger $ "Removing " ++ dir ++ "..."

--- a/hexyll/test/Hexyll/Core/Runtime/Tests.hs
+++ b/hexyll/test/Hexyll/Core/Runtime/Tests.hs
@@ -9,7 +9,6 @@ import Path
 
 --------------------------------------------------------------------------------
 import qualified Data.ByteString     as B
-import           System.FilePath     ((</>))
 import           Test.Tasty          (TestTree, testGroup)
 import           Test.Tasty.HUnit    (Assertion, (@?=))
 

--- a/hexyll/test/Hexyll/Core/Runtime/Tests.hs
+++ b/hexyll/test/Hexyll/Core/Runtime/Tests.hs
@@ -4,6 +4,8 @@ module Hexyll.Core.Runtime.Tests
     ( tests
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import qualified Data.ByteString     as B
@@ -57,20 +59,20 @@ case01 = do
                 makeItem $ concat $ map itemBody (items :: [Item String])
 
     favicon <- B.readFile $
-        providerDirectory testConfiguration </> "images/favicon.ico"
+        (toFilePath . providerDirectory) testConfiguration ++ "images/favicon.ico"
     favicon' <- B.readFile $
-        destinationDirectory testConfiguration </> "images/favicon.ico"
+        (toFilePath . destinationDirectory) testConfiguration ++ "images/favicon.ico"
     favicon @?= favicon'
 
     example <- readFile $
-        destinationDirectory testConfiguration </> "example.html"
+        (toFilePath . destinationDirectory) testConfiguration ** "example.html"
     lines example @?=  ["<p>This is an example.</p>"]
 
-    bodies <- readFile $ destinationDirectory testConfiguration </> "bodies.txt"
+    bodies <- readFile $ (toFilePath . destinationDirectory) testConfiguration ++ "bodies.txt"
     head (lines bodies) @?=  "This is an example."
 
-    partial  <- readFile $ providerDirectory    testConfiguration </> "partial.html.out"
-    partial' <- readFile $ destinationDirectory testConfiguration </> "partial.html.out"
+    partial  <- readFile $ (toFilePath . providerDirectory)    testConfiguration ++ "partial.html.out"
+    partial' <- readFile $ (toFilePath . destinationDirectory) testConfiguration ++ "partial.html.out"
     partial @?= partial'
 
     cleanTestEnv
@@ -90,7 +92,7 @@ case02 = do
             compile copyFileCompiler
 
     favicon <- readFile $
-        destinationDirectory testConfiguration </> "favicon.ico"
+        (toFilePath . destinationDirectory) testConfiguration ++ "favicon.ico"
     favicon @?= "Test"
 
     cleanTestEnv

--- a/hexyll/test/Hexyll/Core/Runtime/Tests.hs
+++ b/hexyll/test/Hexyll/Core/Runtime/Tests.hs
@@ -15,7 +15,7 @@ import           Test.Tasty.HUnit    (Assertion, (@?=))
 
 
 --------------------------------------------------------------------------------
-import           Hexyll
+import           Hexyll hiding (toFilePath)
 import qualified Hexyll.Core.Logger  as Logger
 import           Hexyll.Core.Runtime
 import           TestSuite.Util

--- a/hexyll/test/Hexyll/Core/Runtime/Tests.hs
+++ b/hexyll/test/Hexyll/Core/Runtime/Tests.hs
@@ -65,7 +65,7 @@ case01 = do
     favicon @?= favicon'
 
     example <- readFile $
-        (toFilePath . destinationDirectory) testConfiguration ** "example.html"
+        (toFilePath . destinationDirectory) testConfiguration ++ "example.html"
     lines example @?=  ["<p>This is an example.</p>"]
 
     bodies <- readFile $ (toFilePath . destinationDirectory) testConfiguration ++ "bodies.txt"

--- a/hexyll/test/TestSuite/Util.hs
+++ b/hexyll/test/TestSuite/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 --------------------------------------------------------------------------------
 -- | Test utilities
 module TestSuite.Util
@@ -12,6 +14,8 @@ module TestSuite.Util
     , renderParagraphs
     ) where
 
+import Prelude
+import Path
 
 --------------------------------------------------------------------------------
 import           Data.List                     (intercalate, isInfixOf)
@@ -25,7 +29,7 @@ import           Text.Printf                   (printf)
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Compiler.Internal
 import           Hexyll.Core.Configuration
-import           Hexyll.Core.Identifier
+import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
 import           Hexyll.Core.Store             (Store)
@@ -44,13 +48,13 @@ fromAssertions name =
 
 --------------------------------------------------------------------------------
 newTestStore :: IO Store
-newTestStore = Store.new True $ storeDirectory testConfiguration
+newTestStore = Store.new True $ toFilePath $ storeDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------
 newTestProvider :: Store -> IO Provider
 newTestProvider store = newProvider store (const $ return False) $
-    providerDirectory testConfiguration
+    toFilePath $ providerDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------
@@ -100,19 +104,19 @@ testCompilerError store provider underlying compiler expectedMessage = do
 --------------------------------------------------------------------------------
 testConfiguration :: Configuration
 testConfiguration = defaultConfiguration
-    { destinationDirectory = "_testsite"
-    , storeDirectory       = "_teststore"
-    , tmpDirectory         = "_testtmp"
-    , providerDirectory    = "test/data"
+    { destinationDirectory = $(mkRelDir "_testsite")
+    , storeDirectory       = $(mkRelDir "_teststore")
+    , tmpDirectory         = $(mkRelDir "_testtmp")
+    , providerDirectory    = $(mkRelDir "test/data")
     }
 
 
 --------------------------------------------------------------------------------
 cleanTestEnv :: IO ()
 cleanTestEnv = do
-    removeDirectory $ destinationDirectory testConfiguration
-    removeDirectory $ storeDirectory testConfiguration
-    removeDirectory $ tmpDirectory testConfiguration
+    removeDirectory $ toFilePath $ destinationDirectory testConfiguration
+    removeDirectory $ toFilePath $ storeDirectory testConfiguration
+    removeDirectory $ toFilePath $ tmpDirectory testConfiguration
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/57 .

`Configuration` 型のフィールドの型を `Path` 型へ変更した。

他の個所の変更は `parseRelFile` と `mkRelDir` と `toFilePath` でひたすら型を合わせているだけ。他のモジュールでも `Path` 型を使いたいが、それはそれらのモジュールをリファクタリングするときにでも。

`Core.Identifier` モジュールに `toFilePath` という同名の関数があるのは罠だった。その回避はインポート時に隠すだけで済んだ。