### PR TITLE
Hexyll.Core.Identifier をリファクタリングする

### DIFF
--- a/hexyll-core/package.yaml
+++ b/hexyll-core/package.yaml
@@ -86,7 +86,8 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hexyll-core
-    - hspec       >= 2.5.5 && < 2.7
+    - QuickCheck  >= 2.11.3  && < 2.13
+    - hspec       >= 2.5.5   && < 2.7
   hexyll-core-unit-test:
     main: Spec.hs
     source-dirs: unit-test

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -7,7 +7,7 @@
 -- License:     Apache-2.0
 -- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
 -- Stability:   stable
--- Portability: portable
+-- Portability: non-portable (GHC Extensions: CPP + TemplateHaskell)
 --
 -- This module defines a datastructure for the top-level hexyll configuration.
 module Hexyll.Core.Configuration

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -27,7 +27,7 @@ module Hexyll.Core.Configuration
   import System.Exit    (ExitCode)
   import System.Process (system)
 
-  -- | Top-level hexyll configration.
+  -- | The top-level hexyll configration.
   --
   -- 'providerDirectory' is the current directory @.@ by default. See
   -- 'defaultConfiguration' if you want more information about the default

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -40,6 +40,10 @@ module Hexyll.Core.Identifier
   import qualified Path
   import           Path hiding (toFilePath)
 
+  -- | A type used to uniquely identify an item.
+  --
+  -- It is similar to 'FilePath'. But, a 'Identifier' value can have its
+  -- version. The information about version is used inside the library.
   data Identifier = Identifier
     { identifierVersion :: Maybe String
     , identifierPath    :: Path Rel File

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- |
 -- Module:      Hexyll.Core.Identifier
 -- Copyright:   (c) 2019 Hexirp

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -45,8 +45,12 @@ data Identifier = Identifier
 
 --------------------------------------------------------------------------------
 instance Binary Identifier where
-    put (Identifier v p) = put v >> put p
-    get = Identifier <$> get <*> get
+    put (Identifier v p) = put v >> put (Path.toFilePath p)
+    get = Identifier <$> get <*> do
+      s <- get
+      case parseRelFile s of
+        Nothing -> mzero
+        Just p -> return p
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -1,14 +1,24 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- | An identifier is a type used to uniquely identify an item. An identifier is
--- conceptually similar to a file path. Examples of identifiers are:
+-- |
+-- Module:      Hexyll.Core.Identifier
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module defines 'Identifier', a type used to uniquely identify an item.
+-- An identifier is conceptually similar to a file path. Examples of
+-- identifiers are:
 --
 -- * @posts/foo.markdown@
---
 -- * @index@
---
 -- * @error/404@
+--
+-- A 'Identifier' value can have its version. The information about version is
+-- used inside the library.
 module Hexyll.Core.Identifier
   ( Identifier
   , fromFilePath

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -74,7 +74,7 @@ instance Show Identifier where
 -- | Parse an identifier from a string
 fromFilePath :: FilePath -> Identifier
 fromFilePath s = case parseRelFile s of
-  Nothing -> error "Identifier.fromFilePath: It is not a relative path to file."
+  Nothing -> error "Identifier.fromFilePath: It's not a relative path to file."
   Just p -> Identifier Nothing p
 
 

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -51,7 +51,7 @@ module Hexyll.Core.Identifier
     , identifierPath    :: Path Rel File
     } deriving (Eq, Ord, Typeable)
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance Binary Identifier where
     put (Identifier v p) = do
       put v
@@ -65,15 +65,15 @@ module Hexyll.Core.Identifier
           Just p -> return p
       return $ Identifier v p
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance IsString Identifier where
     fromString = fromFilePath
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance NFData Identifier where
     rnf (Identifier v p) = rnf v `seq` rnf p `seq` ()
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance Show Identifier where
     show i = case identifierVersion i of
         Nothing -> toFilePath i

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -13,8 +13,8 @@ module Hexyll.Core.Identifier
     ( Identifier
     , fromFilePath
     , toFilePath
-    , identifierVersion
-    , setVersion
+    , getIdentVersion
+    , setIdentVersion
     ) where
 
 import Prelude
@@ -85,6 +85,9 @@ toFilePath :: Identifier -> FilePath
 toFilePath = Path.toFilePath . identifierPath
 
 
+getIdentVersion :: Identifier -> Maybe String
+getIdentVersion = identifierVersion
+
 --------------------------------------------------------------------------------
-setVersion :: Maybe String -> Identifier -> Identifier
-setVersion v i = i { identifierVersion = i }
+setIdentVersion :: Maybe String -> Identifier -> Identifier
+setIdentVersion v i = i { identifierVersion = v }

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -46,12 +46,17 @@ data Identifier = Identifier
 
 --------------------------------------------------------------------------------
 instance Binary Identifier where
-    put (Identifier v p) = put v >> put (Path.toFilePath p)
-    get = Identifier <$> get <*> do
-      s <- get
-      case parseRelFile s of
-        Nothing -> mzero
-        Just p -> return p
+    put (Identifier v p) = do
+      put v
+      put $ Path.toFilePath p
+    get = do
+      v <- get
+      p <- do
+        s <- get
+        case parseRelFile s of
+          Nothing -> mzero
+          Just p -> return p
+      return $ Identifier v p
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -87,4 +87,4 @@ toFilePath = Path.toFilePath . identifierPath
 
 --------------------------------------------------------------------------------
 setVersion :: Maybe String -> Identifier -> Identifier
-setVersion v i = i {identifierVersion = v}
+setVersion v i = i { identifierVersion = i }

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -24,11 +24,6 @@ import qualified Path
 
 --------------------------------------------------------------------------------
 import           Control.DeepSeq     (NFData (..))
-import           Data.List           (intercalate)
-import           System.FilePath     ( pathSeparator
-                                     , dropTrailingPathSeparator
-                                     , splitPath
-                                     )
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -44,11 +44,14 @@ module Hexyll.Core.Identifier
   --
   -- It is similar to 'FilePath'. But, a 'Identifier' value can have its
   -- version. The information about version is used inside the library.
+  --
+  -- @since 0.1.0.0
   data Identifier = Identifier
     { identifierVersion :: Maybe String
     , identifierPath    :: Path Rel File
     } deriving (Eq, Ord, Typeable)
 
+  -- @since 0.1.0.0
   instance Binary Identifier where
     put (Identifier v p) = do
       put v
@@ -62,29 +65,45 @@ module Hexyll.Core.Identifier
           Just p -> return p
       return $ Identifier v p
 
+  -- @since 0.1.0.0
   instance IsString Identifier where
     fromString = fromFilePath
 
+  -- @since 0.1.0.0
   instance NFData Identifier where
     rnf (Identifier v p) = rnf v `seq` rnf p `seq` ()
 
+  -- @since 0.1.0.0
   instance Show Identifier where
     show i = case identifierVersion i of
         Nothing -> toFilePath i
         Just v  -> toFilePath i ++ " (" ++ v ++ ")"
 
-  -- | Parse an identifier from a string
+  -- | Parse an identifier from a string. The string should be a relative path
+  -- to file.
+  --
+  -- @since 0.1.0.0
   fromFilePath :: FilePath -> Identifier
   fromFilePath s = case parseRelFile s of
     Nothing -> error "Identifier.fromFilePath: It's not a relative path to file."
     Just p -> Identifier Nothing p
 
-  -- | Convert an identifier to a relative 'FilePath'
+  -- | Convert an identifier to a relative 'FilePath'.
+  --
+  -- @since 0.1.0.0
   toFilePath :: Identifier -> FilePath
   toFilePath = Path.toFilePath . identifierPath
 
+  -- | Get the version of an identifier. I recommend that you do not use this
+  -- function.
+  --
+  -- @since 0.1.0.0
   getIdentVersion :: Identifier -> Maybe String
   getIdentVersion = identifierVersion
 
+  -- | Set the version of an identifier. I recommend that you do not use this
+  -- function.
+  --
+  -- @since 0.1.0.0
   setIdentVersion :: Maybe String -> Identifier -> Identifier
   setIdentVersion v i = i { identifierVersion = v }

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -18,6 +18,7 @@ module Hexyll.Core.Identifier
     ) where
 
 import Prelude
+import Control.Monad (mzero)
 import Path hiding (toFilePath)
 import qualified Path
 

--- a/hexyll-core/src/Hexyll/Core/Identifier.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier.hs
@@ -17,6 +17,9 @@ module Hexyll.Core.Identifier
     , setVersion
     ) where
 
+import Prelude
+import Path hiding (toFilePath)
+import qualified Path
 
 --------------------------------------------------------------------------------
 import           Control.DeepSeq     (NFData (..))
@@ -36,7 +39,7 @@ import           GHC.Exts            (IsString, fromString)
 --------------------------------------------------------------------------------
 data Identifier = Identifier
     { identifierVersion :: Maybe String
-    , identifierPath    :: String
+    , identifierPath    :: Path Rel File
     } deriving (Eq, Ord, Typeable)
 
 
@@ -66,18 +69,15 @@ instance Show Identifier where
 --------------------------------------------------------------------------------
 -- | Parse an identifier from a string
 fromFilePath :: FilePath -> Identifier
-fromFilePath = Identifier Nothing .
-    intercalate "/" . filter (not . null) . split'
-  where
-    split' = map dropTrailingPathSeparator . splitPath
+fromFilePath s = case parseRelFile s of
+  Nothing -> error "Identifier.fromFilePath: It is not a relative path to file."
+  Just p -> Identifier Nothing p
 
 
 --------------------------------------------------------------------------------
 -- | Convert an identifier to a relative 'FilePath'
 toFilePath :: Identifier -> FilePath
-toFilePath = intercalate [pathSeparator] . split' . identifierPath
-  where
-    split' = map dropTrailingPathSeparator . splitPath
+toFilePath = Path.toFilePath . identifierPath
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Identifier/Pattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/Pattern.hs
@@ -183,7 +183,7 @@ matches (And x y)      i = matches x i && matches y i
 matches (Glob p)       i = isJust $ capture (Glob p) i
 matches (List l)       i = i `S.member` l
 matches (Regex r)      i = toFilePath i =~ r
-matches (Version v)    i = identifierVersion i == v
+matches (Version v)    i = getIdentVersion i == v
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Identifier/Pattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/Pattern.hs
@@ -113,7 +113,7 @@ fromGlob = Glob . parse'
 --
 -- The correct way to use this is:
 --
--- > fromList $ map (setVersion $ Just "pdf") ["foo.markdown"]
+-- > fromList $ map (setIdentVersion $ Just "pdf") ["foo.markdown"]
 fromList :: [Identifier] -> Pattern
 fromList = List . S.fromList
 

--- a/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
@@ -137,7 +137,7 @@ resourceList = M.keys . providerFiles
 -- | Check if a given resource exists
 resourceExists :: Provider -> Identifier -> Bool
 resourceExists provider =
-    (`M.member` providerFiles provider) . setVersion Nothing
+    (`M.member` providerFiles provider) . setIdentVersion Nothing
 
 
 --------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ resourceModified p r = case (ri, oldRi) of
         resourceInfoModified n >  resourceInfoModified o ||
         resourceInfoMetadata n /= resourceInfoMetadata o
   where
-    normal = setVersion Nothing r
+    normal = setIdentVersion Nothing r
     ri     = M.lookup normal (providerFiles p)
     oldRi  = M.lookup normal (providerOldFiles p)
 
@@ -175,7 +175,7 @@ resourceModified p r = case (ri, oldRi) of
 --------------------------------------------------------------------------------
 resourceModificationTime :: Provider -> Identifier -> UTCTime
 resourceModificationTime p i =
-    case M.lookup (setVersion Nothing i) (providerFiles p) of
+    case M.lookup (setIdentVersion Nothing i) (providerFiles p) of
         Just ri -> unBinaryTime $ resourceInfoModified ri
         Nothing -> error $
             "Hexyll.Core.Provider.Internal.resourceModificationTime: " ++

--- a/hexyll-core/src/Hexyll/Core/Provider/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Metadata.hs
@@ -44,7 +44,7 @@ loadMetadata p identifier = do
 
     return (md <> emd, body)
   where
-    normal = setVersion Nothing identifier
+    normal = setIdentVersion Nothing identifier
     fp     = resourceFilePath p identifier
     mi     = M.lookup normal (providerFiles p) >>= resourceInfoMetadata
 

--- a/hexyll-core/src/Hexyll/Core/Rules.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules.hs
@@ -96,15 +96,15 @@ flush = Rules $ do
             route'   <- fromMaybe mempty . rulesRoute <$> get
 
             -- The version is possibly not set correctly at this point (yet)
-            let ids = map (setVersion version') matches'
+            let ids = map (setIdentVersion version') matches'
 
             {-
             ids      <- case fromLiteral pattern of
-                Just id' -> return [setVersion version' id']
+                Just id' -> return [setIdentVersion version' id']
                 Nothing  -> do
                     ids <- unRules $ getMatches pattern
                     unRules $ tellResources ids
-                    return $ map (setVersion version') ids
+                    return $ map (setIdentVersion version') ids
             -}
 
             -- Create a fast pattern for routing that matches exactly the
@@ -154,9 +154,9 @@ create ids rules = do
 version :: String -> Rules () -> Rules ()
 version v rules = do
     flush
-    Rules $ local setVersion' $ unRules $ rules >> flush
+    Rules $ local setIdentVersion' $ unRules $ rules >> flush
   where
-    setVersion' env = env {rulesVersion = Just v}
+    setIdentVersion' env = env {rulesVersion = Just v}
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -3,7 +3,9 @@
 module Hexyll.Core.IdentifierSpec (spec) where
 
   import Prelude
+
   import Test.Hspec
+  import Test.QuickCheck
 
   import Control.Exception (evaluate)
   import Control.DeepSeq

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -22,17 +22,23 @@ module Hexyll.Core.IdentifierSpec (spec) where
 
       it "can not parse 'foo/'" $ do
         (evaluate $ fromFilePath "foo/") `shouldThrow` anyErrorCall
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+
+      it "can not parse 'C:\\foo.md'" $ do
+        (evaluate $ fromFilePath "C:\\foo.md") `shouldThrow` anyErrorCall
+#else
 
       it "can not parse '/foo.md'" $ do
         (evaluate $ fromFilePath "/foo.md") `shouldThrow` anyErrorCall
+#endif
 
     describe "toFilePath" $ do
 #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
 
-      it "returns a path with '/' separated" $ do
+      it "returns a path with '\\' separated" $ do
         (toFilePath $ fromFilePath "foo\\bar.md") `shouldBe` "foo\\bar.md"
 
-      it "returns a path with '/' separated (form posix)" $ do
+      it "returns a path with '\\' separated (posix style)" $ do
         (toFilePath $ fromFilePath "foo/bar.md") `shouldBe` "foo\\bar.md"
 #else
 

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -5,6 +5,8 @@ module Hexyll.Core.IdentifierSpec (spec) where
   import Prelude
   import Test.Hspec
 
+  import Control.DeepSeq
+
   spec :: Spec
   spec = do
 

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -1,0 +1,7 @@
+module Hexyll.Core.IdentifierSpec (spec) where
+
+  import Prelude
+  import Test.HSpec
+
+  spec :: Spec
+  spec = return ()

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -67,20 +67,20 @@ module Hexyll.Core.IdentifierSpec (spec) where
   prop_get_set_IdentVersion :: Maybe String -> Bool
   prop_get_set_IdentVersion s =
     let
-      i = make_Identifier_0
+      i = mock_Identifier_0
     in
       getIdentVersion (setIdentVersion s i) == s
 
   prop_set_get_IdentVersion :: Maybe String -> Bool
   prop_set_get_IdentVersion s =
     let
-      i = make_Identifier_1 s
+      i = mock_Identifier_1 s
     in
       setIdentVersion (getIdentVersion i) i == i
 
   prop_set_set_IdentVersion :: Maybe String -> Maybe String -> Bool
   prop_set_set_IdentVersion s0 s1 =
     let
-      i = make_Identifier_0
+      i = mock_Identifier_0
     in
       setIdentVersion s0 (setIdentVersion s1 i) == setIdentVersion s0 i

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -5,6 +5,7 @@ module Hexyll.Core.IdentifierSpec (spec) where
   import Prelude
   import Test.Hspec
 
+  import Control.Exception (evaluate)
   import Control.DeepSeq
 
   import Hexyll.Core.Identifier

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -37,3 +37,42 @@ module Hexyll.Core.IdentifierSpec (spec) where
       it "returns a path with '/' separated" $ do
         (toFilePath $ fromFilePath "foo/bar.md") `shouldBe` "foo/bar.md"
 #endif
+
+    describe "getIdentVersion" $ do
+
+      it "follows the law 'get (set s i) === s'" $
+        property prop_get_set_IdentVersion
+
+    describe "setIdentVersion" $ do
+
+      it "follows the law 'set (get i) i === i'" $
+        property prop_set_get_IdentVersion
+
+      it "follows the law 'set s0 (set s1 i) === set s0 i'" $
+        property prop_set_set_IdentVersion
+
+
+  -- Functions to test getIdentVersion and setIdentVersion
+
+  -- The mock without a identifier version
+  mock_Identifier_0 :: Identifier
+  mock_Identifier_0 = fromFilePath "foo.c"
+
+  -- The mock with a identifier version
+  mock_Identifier_1 :: Maybe String -> Identifier
+  mock_Identifier_1 s = setIdentVersion s mock_Identifier_0
+
+  prop_get_set_IdentVersion :: Maybe String -> Bool
+  prop_get_set_IdentVersion s =
+    (getIdentVersion . setIdentVersion s) mock_Identifier_0 == s
+
+  prop_set_get_IdentVersion :: Maybe String -> Bool
+  prop_set_get_IdentVersion s =
+    let
+      i = make_Identifier_1 s
+    in
+      setIdentVersion (getIdentVersion i) i == i
+
+  prop_set_set_IdentVersion :: Maybe String -> Maybe String -> Bool
+  prop_set_set_IdentVersion s0 s1 =
+    setIdentVersion s0 (setIdentVersion s1 i) = setIdentVersion s0 i

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -66,7 +66,10 @@ module Hexyll.Core.IdentifierSpec (spec) where
 
   prop_get_set_IdentVersion :: Maybe String -> Bool
   prop_get_set_IdentVersion s =
-    (getIdentVersion . setIdentVersion s) mock_Identifier_0 == s
+    let
+      i = make_Identifier_0
+    in
+      getIdentVersion (setIdentVersion s i) == s
 
   prop_set_get_IdentVersion :: Maybe String -> Bool
   prop_set_get_IdentVersion s =
@@ -77,4 +80,7 @@ module Hexyll.Core.IdentifierSpec (spec) where
 
   prop_set_set_IdentVersion :: Maybe String -> Maybe String -> Bool
   prop_set_set_IdentVersion s0 s1 =
-    setIdentVersion s0 (setIdentVersion s1 i) == setIdentVersion s0 i
+    let
+      i = make_Identifier_0
+    in
+      setIdentVersion s0 (setIdentVersion s1 i) == setIdentVersion s0 i

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -7,6 +7,8 @@ module Hexyll.Core.IdentifierSpec (spec) where
 
   import Control.DeepSeq
 
+  import Hexyll.Core.Identifier
+
   spec :: Spec
   spec = do
 

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -1,7 +1,7 @@
 module Hexyll.Core.IdentifierSpec (spec) where
 
   import Prelude
-  import Test.HSpec
+  import Test.Hspec
 
   spec :: Spec
   spec = return ()

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -77,4 +77,4 @@ module Hexyll.Core.IdentifierSpec (spec) where
 
   prop_set_set_IdentVersion :: Maybe String -> Maybe String -> Bool
   prop_set_set_IdentVersion s0 s1 =
-    setIdentVersion s0 (setIdentVersion s1 i) = setIdentVersion s0 i
+    setIdentVersion s0 (setIdentVersion s1 i) == setIdentVersion s0 i

--- a/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/IdentifierSpec.hs
@@ -1,7 +1,34 @@
+{-# LANGUAGE CPP #-}
+
 module Hexyll.Core.IdentifierSpec (spec) where
 
   import Prelude
   import Test.Hspec
 
   spec :: Spec
-  spec = return ()
+  spec = do
+
+    describe "fromFilePath" $ do
+
+      it "can parse 'foo.txt'" $ do
+        rnf (fromFilePath "foo.txt") `shouldBe` ()
+
+      it "can not parse 'foo/'" $ do
+        (evaluate $ fromFilePath "foo/") `shouldThrow` anyErrorCall
+
+      it "can not parse '/foo.md'" $ do
+        (evaluate $ fromFilePath "/foo.md") `shouldThrow` anyErrorCall
+
+    describe "toFilePath" $ do
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+
+      it "returns a path with '/' separated" $ do
+        (toFilePath $ fromFilePath "foo\\bar.md") `shouldBe` "foo\\bar.md"
+
+      it "returns a path with '/' separated (form posix)" $ do
+        (toFilePath $ fromFilePath "foo/bar.md") `shouldBe` "foo\\bar.md"
+#else
+
+      it "returns a path with '/' separated" $ do
+        (toFilePath $ fromFilePath "foo/bar.md") `shouldBe` "foo/bar.md"
+#endif

--- a/hexyll-core/unit-test/Hexyll/Core/IdentifierTest.hs
+++ b/hexyll-core/unit-test/Hexyll/Core/IdentifierTest.hs
@@ -50,12 +50,12 @@ captureTests = fromAssertions "capture"
 matchesTests :: [TestTree]
 matchesTests = fromAssertions "matches"
     [ True  @=? matches (fromList ["foo.markdown"]) "foo.markdown"
-    , False @=? matches (fromList ["foo"]) (setVersion (Just "x") "foo")
-    , True  @=? matches (fromVersion (Just "xz")) (setVersion (Just "xz") "bar")
+    , False @=? matches (fromList ["foo"]) (setIdentVersion (Just "x") "foo")
+    , True  @=? matches (fromVersion (Just "xz")) (setIdentVersion (Just "xz") "bar")
     , True  @=? matches (fromRegex "^foo/[^x]*$") "foo/bar"
     , False @=? matches (fromRegex "^foo/[^x]*$") "foo/barx"
     , True  @=? matches (complement "foo.markdown") "bar.markdown"
     , False @=? matches (complement "foo.markdown") "foo.markdown"
     , True  @=? matches ("foo" .||. "bar") "bar"
-    , False @=? matches ("bar" .&&. hasNoVersion) (setVersion (Just "xz") "bar")
+    , False @=? matches ("bar" .&&. hasNoVersion) (setIdentVersion (Just "xz") "bar")
     ]

--- a/hexyll-core/unit-test/Hexyll/Core/RulesTest.hs
+++ b/hexyll-core/unit-test/Hexyll/Core/RulesTest.hs
@@ -52,7 +52,7 @@ case01 = do
     readIORef ioref >>= (True @=?)
     cleanTestEnv
   where
-    sv g     = setVersion (Just g)
+    sv g     = setIdentVersion (Just g)
     expected =
         [                    "example.md"
         , sv "raw"           "example.md"


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/63 .

Hexyll.Core.Identifier をリファクタリングする。

`identifierPath` のフィールドを `FilePath` 型から `Path Rel File` 型に変更した。また、その意味論を「スラッシュで区切られているパス」から「環境に合ったパス区切りのファイルへの相対パス」へ変更した。この元々の意味論は https://github.com/jaspervdj/hakyll/pull/664 で Jasper Van der Jeugt 氏が話していた。

`getIdentVersion` と `setIdentVersion` へとバージョンをゲットあるいはセットする関数を切り替えた。元々の名前は一貫しておらず、フィールドの関数を直接参照していたため。

その他にも様々な整理を行った。

## この後

`Show` 型クラスのインスタンスは、現在は独自実装になっているが、これは通常の実装にしてもいいのではないか。

`getIdentVersion` と `setIdentVersion` は内部モジュールのような場所に動かしたほうがいいのではないか。現在ライブラリの内部で使われているが、ユーザーがこれを使う必要があるとは思えない。