### PR TITLE
Hexyll.Core.Dependencies をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -350,5 +350,5 @@ compilerGetMatches pattern = do
     universe <- compilerUniverse <$> compilerAsk
     let matching = filterMatches pattern $ S.toList universe
         set'     = S.fromList matching
-    compilerTellDependencies [PatternDependency pattern set']
+    compilerTellDependencies [PatternDependency (toNew pattern) set']
     return matching

--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -31,7 +31,7 @@ import           Hexyll.Core.Identifier.Pattern
 
 --------------------------------------------------------------------------------
 data Dependency
-    = PatternDependency Pattern (Set Identifier)
+    = PatternDependency PatternExpr (Set Identifier)
     | IdentifierDependency Identifier
     deriving (Show, Typeable)
 

--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -115,7 +115,7 @@ checkChangedPatterns = do
     go _   ds (IdentifierDependency i) = return $ IdentifierDependency i : ds
     go id' ds (PatternDependency p ls) = do
         universe <- ask
-        let ls' = S.fromList $ filterMatches p universe
+        let ls' = S.fromList $ filter (`matchExpr` p) universe
         if ls == ls'
             then return $ PatternDependency p ls : ds
             else do

--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -26,7 +26,7 @@ import           Data.Typeable                  (Typeable)
 
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
-import           Hexyll.Core.Identifier.OldPattern
+import           Hexyll.Core.Identifier.Pattern
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -29,38 +29,32 @@ import           Hexyll.Core.Identifier.Pattern
 
 
 --------------------------------------------------------------------------------
-newtype Dependency = Dependency { unDependency :: PatternExpr }
-  deriving (Eq, Show)
+data Dependency
+    = PatternDependency PatternExpr (Set Identifier)
+    | IdentifierDependency Identifier
+    deriving (Show, Typeable)
 
+
+--------------------------------------------------------------------------------
 instance Binary Dependency where
-  put (Dependency x) = put x
-  get = Dependency <$> get
+    put (PatternDependency p is) = putWord8 0 >> put p >> put is
+    put (IdentifierDependency i) = putWord8 1 >> put i
+    get = getWord8 >>= \t -> case t of
+        0 -> PatternDependency <$> get <*> get
+        1 -> IdentifierDependency <$> get
+        _ -> error "Data.Binary.get: Invalid Dependency"
 
-newtype DependencyFacts
-  = DependencyFacts { unDependencyFacts :: Map Identifier [Dependency] }
-  deriving (Eq, Show)
 
-newtype DependencyCache
-  = DependencyCache { unDependencyCache :: Map Identifier [Identifier] }
-  deriving (Eq, Show)
+--------------------------------------------------------------------------------
+type DependencyFacts = Map Identifier [Dependency]
 
-newtype DependencyLog = DependencyLog { unDependencyLog :: String -> String }
 
-instance Semigroup DependencyLog where
-  DependencyLog x <> DependencyLog y = DependencyLog (x <> y)
-
-instance Monoid DependencyLog where
-  mempty = DependencyLog mempty
-
-type KnownIdentifierList = [Identifier]
-type MarkedIdentifierList = [Identifier]
-
+--------------------------------------------------------------------------------
 outOfDate
-  :: KnownIdentifierList
-  -> MarkedIdentifierList
-  -> DependencyFacts
-  -> DependencyCache
-  -> (MarkedIdentifierList, DependencyCache, DependencyLog)
+    :: [Identifier]     -- ^ All known identifiers
+    -> Set Identifier   -- ^ Initially out-of-date resources
+    -> DependencyFacts  -- ^ Old dependency facts
+    -> (Set Identifier, DependencyFacts, [String])
 outOfDate universe ood oldFacts =
     let (_, state, logs) = runRWS rws universe (DependencyState oldFacts ood)
     in (dependencyOod state, dependencyFacts state, logs)

--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -1,5 +1,4 @@
 --------------------------------------------------------------------------------
-{-# LANGUAGE DeriveDataTypeable #-}
 module Hexyll.Core.Dependencies
     ( Dependency (..)
     , DependencyFacts

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -291,9 +291,6 @@ capture' (CaptureMany : ms) str =
 
 
 
--- | Convert a 'Pattern' to a 'New.Pattern'.
---
--- @since 0.1.0.0
 toNew :: Pattern -> New.Pattern
 toNew Everything = New.everything
 toNew (Complement xc) = complement (toNew xc)
@@ -302,3 +299,10 @@ toNew (List is) = S.foldr (\i p -> (New.fromGlob (toFilePath i) .&&. New.fromVer
 toNew (Glob g) = New.fromGlob (decompile g)
 toNew (Regex r) = New.fromRegex r
 toNew (Version mv) = New.fromVersion mv
+
+decompile :: [GlobComponet] -> String
+decompile = concatMap f where
+  f :: GlobComponent -> String
+  f Capture = "*"
+  f CaptureMany = "**"
+  f (Literal s) = s

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -73,6 +73,7 @@ import           Data.Set               (Set)
 
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
+import qualified Hexyll.Core.Identifier.Pattern as New
 
 
 --------------------------------------------------------------------------------
@@ -286,3 +287,18 @@ capture' (Capture : ms) str =
 capture' (CaptureMany : ms) str =
     -- Match everything
     msum $ [ fmap (i :) (capture' ms t) | (i, t) <- splits str ]
+
+
+
+
+-- | Convert a 'Pattern' to a 'New.Pattern'.
+--
+-- @since 0.1.0.0
+toNew :: Pattern -> New.Pattern
+toNew Everything = New.everything
+toNew (Complement xc) = complement (toNew xc)
+toNew (And x0 x1) = toNew x0 New..&&. toNew x1
+toNew (List is) = S.foldr (\i p -> (New.fromGlob (toFilePath i) .&&. New.fromVersion (getIdentVersion i)) .||. p) New.nothing is
+toNew (Glog g) = New.fromGlob (decompile g)
+toNew (Regex r) = New.fromRegex r
+toNew (Version mv) = New.fromVersion mv

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -29,7 +29,7 @@
 -- The 'capture' function allows the user to get access to the elements captured
 -- by the capture elements in a glob or regex pattern.
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Hexyll.Core.Identifier.OldPattern
+module Hexyll.Core.Identifier.OldPattern {-# DEPRECATED "Use Hexyll.Core.Identifier.Pattern instead of" #-}
     ( -- * The pattern type
       Pattern
 

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -49,6 +49,8 @@ module Hexyll.Core.Identifier.OldPattern
       -- * Applying patterns
     , matches
     , filterMatches
+
+    , toNew
     ) where
 
 

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -300,7 +300,7 @@ toNew (Glob g) = New.fromGlob (decompile g)
 toNew (Regex r) = New.fromRegex r
 toNew (Version mv) = New.fromVersion mv
 
-decompile :: [GlobComponet] -> String
+decompile :: [GlobComponent] -> String
 decompile = concatMap f where
   f :: GlobComponent -> String
   f Capture = "*"

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -299,6 +299,6 @@ toNew Everything = New.everything
 toNew (Complement xc) = complement (toNew xc)
 toNew (And x0 x1) = toNew x0 New..&&. toNew x1
 toNew (List is) = S.foldr (\i p -> (New.fromGlob (toFilePath i) .&&. New.fromVersion (getIdentVersion i)) .||. p) New.nothing is
-toNew (Glog g) = New.fromGlob (decompile g)
+toNew (Glob g) = New.fromGlob (decompile g)
 toNew (Regex r) = New.fromRegex r
 toNew (Version mv) = New.fromVersion mv

--- a/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
+++ b/hexyll-core/src/Hexyll/Core/Identifier/OldPattern.hs
@@ -291,11 +291,11 @@ capture' (CaptureMany : ms) str =
 
 
 
-toNew :: Pattern -> New.Pattern
+toNew :: Pattern -> New.PatternExpr
 toNew Everything = New.everything
-toNew (Complement xc) = complement (toNew xc)
+toNew (Complement xc) = New.complement (toNew xc)
 toNew (And x0 x1) = toNew x0 New..&&. toNew x1
-toNew (List is) = S.foldr (\i p -> (New.fromGlob (toFilePath i) .&&. New.fromVersion (getIdentVersion i)) .||. p) New.nothing is
+toNew (List is) = S.foldr (\i p -> (New.fromGlob (toFilePath i) New..&&. New.fromVersion (getIdentVersion i)) New..||. p) New.nothing is
 toNew (Glob g) = New.fromGlob (decompile g)
 toNew (Regex r) = New.fromRegex r
 toNew (Version mv) = New.fromVersion mv

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -80,7 +80,7 @@ getMetadataField' identifier key = do
 makePatternDependency :: MonadMetadata m => Pattern -> m Dependency
 makePatternDependency pattern = do
     matches' <- getMatches pattern
-    return $ PatternDependency pattern (S.fromList matches')
+    return $ PatternDependency (toNew pattern) (S.fromList matches')
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Web/Paginate.hs
+++ b/hexyll/src/Hexyll/Web/Paginate.hs
@@ -68,7 +68,7 @@ buildPaginateWith grouper pattern makeId = do
     return Paginate
         { paginateMap        = M.fromList (zip [1 ..] idGroups)
         , paginateMakeId     = makeId
-        , paginateDependency = PatternDependency pattern idsSet
+        , paginateDependency = PatternDependency (toNew pattern) idsSet
         }
 
 

--- a/hexyll/src/Hexyll/Web/Tags.hs
+++ b/hexyll/src/Hexyll/Web/Tags.hs
@@ -129,7 +129,7 @@ buildTagsWith f pattern makeId = do
     ids    <- getMatches pattern
     tagMap <- foldM addTags M.empty ids
     let set' = S.fromList ids
-    return $ Tags (M.toList tagMap) makeId (PatternDependency pattern set')
+    return $ Tags (M.toList tagMap) makeId (PatternDependency (toNew pattern) set')
   where
     -- Create a tag map for one page
     addTags tagMap id' = do


### PR DESCRIPTION
See https://github.com/Hexirp/hexirp-hakyll/issues/69 .

Hexyll.Core.Dependencies をリファクタリングする。今回は `Dependency` 型の内部で使われているパターンを表すための型を `PatternExpr` へ変更した。それだけである。

これからの方針は `outOfDate` の型を定めて適切にプログラムを記述した後、それらに合わせて他のモジュールを変更する。また `Dependency` の型は `PatternExpr` のラップとする。