### PR TITLE
H.C.Dependencies のユーティリティを追加する

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Dependencies.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies.hs
@@ -11,7 +11,13 @@
 module Hexyll.Core.Dependencies
   ( Dependency (..)
   , DependencyFacts (..)
+  , emptyFacts
+  , lookupFacts
+  , insertFacts
   , DependencyCache (..)
+  , emptyCache
+  , lookupCache
+  , insertCache
   , IdentifierUniverse
   , IdentifierOutOfDate
   , CalculationLog

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -316,14 +316,14 @@ module Hexyll.Core.Dependencies.Internal where
   check = do
     universe <- askUniverse
     forM_ universe $ \i -> do
-      m_ois <- lookupOldCache i
+      m_ois <- askLookupOldCache i
       case m_ois of
         Nothing -> do
           tellLog $ show i ++ " is out-of-date because it is new"
           markOutOfDate i
         Just ois -> do
           nis <- dependenciesFor i
-          insertNewCache i nis
+          modifyInsertNewCache i nis
           when (ois /= nis) $ do
             tellLog $ show i ++ " is out-of-date because its pattern changed"
             markOutOfDate i
@@ -336,8 +336,8 @@ module Hexyll.Core.Dependencies.Internal where
   dependenciesFor :: Identifier -> DependencyM [Identifier]
   dependenciesFor i = do
     universe <- askUniverse
-    ds <- lookupFacts i
-    m_is <- lookupNewCache i
+    ds <- askLookupFacts i
+    m_is <- getLookupNewCache i
     case m_is of
       Nothing -> return $ concat $ for ds $ \d ->
         filter (`matchExpr` unDependency d) universe

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -228,8 +228,8 @@ module Hexyll.Core.Dependencies.Internal where
   -- 'DependencyFacts' on 'DependencyM'.
   --
   -- @since 0.1.0.0
-  lookupFacts :: Identifier -> DependencyM [Dependency]
-  lookupFacts i = do
+  askLookupFacts :: Identifier -> DependencyM [Dependency]
+  askLookupFacts i = do
     facts <- askFacts
     return $ fromMaybe [] $ M.lookup i $ unDependencyFacts facts
 
@@ -250,8 +250,8 @@ module Hexyll.Core.Dependencies.Internal where
   -- 'DependencyCache' on 'DependencyM'.
   --
   -- @since 0.1.0.0
-  lookupOldCache :: Identifier -> DependencyM (Maybe [Identifier])
-  lookupOldCache i = do
+  askLookupOldCache :: Identifier -> DependencyM (Maybe [Identifier])
+  askLookupOldCache i = do
     dc <- askOldCache
     return $ M.lookup i $ unDependencyCache dc
 
@@ -266,8 +266,8 @@ module Hexyll.Core.Dependencies.Internal where
   -- 'DependencyCache' on 'DependencyM'.
   --
   -- @since 0.1.0.0
-  lookupNewCache :: Identifier -> DependencyM (Maybe [Identifier])
-  lookupNewCache i = do
+  getLookupNewCache :: Identifier -> DependencyM (Maybe [Identifier])
+  getLookupNewCache i = do
     dc <- getNewCache
     return $ M.lookup i $ unDependencyCache dc
 
@@ -275,8 +275,8 @@ module Hexyll.Core.Dependencies.Internal where
   -- 'DependencyCache' on 'DependencyM'.
   --
   -- @since 0.1.0.0
-  insertNewCache :: Identifier -> [Identifier] -> DependencyM ()
-  insertNewCache i is = rws $ \_ s -> case s of
+  modifyInsertNewCache :: Identifier -> [Identifier] -> DependencyM ()
+  modifyInsertNewCache i is = rws $ \_ s -> case s of
     DependencyState dc io ->
       let
         dc' = DependencyCache $ M.insert i is $ unDependencyCache dc

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -19,11 +19,11 @@ module Hexyll.Core.Dependencies.Internal where
 
   import           Data.DList    ( DList, toList, singleton )
   import           Data.List     ( find )
-  import qualified Data.Map as M
   import           Data.Map      ( Map )
+  import qualified Data.Map as M
   import           Data.Maybe    ( fromMaybe )
-  import qualified Data.Set as S
   import           Data.Set      ( Set )
+  import qualified Data.Set as S
 
   import Control.Monad    ( forM_, when )
   import Data.Traversable ( for )
@@ -65,6 +65,28 @@ module Hexyll.Core.Dependencies.Internal where
   instance NFData DependencyFacts where
     rnf (DependencyFacts x) = rnf x
 
+  -- | The empty 'DependencyFacts'.
+  --
+  -- @since 0.1.0.0
+  emptyFacts :: DependencyFacts
+  emptyFacts = DependencyFacts M.empty
+
+  -- | Lookup the value at a key in the 'DependencyFacts'.
+  --
+  -- @since 0.1.0.0
+  lookupFacts :: Identifier -> DependencyFacts -> [Dependency]
+  lookupFacts i (DependencyFacts df) = M.lookup i df
+
+  -- | Insert a new key and value in the 'DependencyFacts'.
+  --
+  -- @since 0.1.0.0
+  insertFacts
+    :: Identifier
+    -> [Dependency]
+    -> DependencyFacts
+    -> DependencyFacts
+  insertFacts i ds (DependencyFacts df) = DependencyFacts $ M.insert i ds df
+
   -- | A type of caches of dependency factors.
   --
   -- This can be viewed as an adjacency list representation of a directed
@@ -83,6 +105,28 @@ module Hexyll.Core.Dependencies.Internal where
   -- | @since 0.1.0.0
   instance NFData DependencyCache where
     rnf (DependencyCache x) = rnf x
+
+  -- | The empty 'DependencyCache'.
+  --
+  -- @since 0.1.0.0
+  emptyCache :: DependencyCache
+  emptyCache = DependencyCache M.empty
+
+  -- | Lookup the value at a key in the 'DependencyCache'.
+  --
+  -- @since 0.1.0.0
+  lookupCache :: Identifier -> DependencyCache -> [Identifier]
+  lookupCache i (DependencyCache df) = M.lookup i df
+
+  -- | Insert a new key and value in the 'DependencyCache'.
+  --
+  -- @since 0.1.0.0
+  insertCache
+    :: Identifier
+    -> [Identifier]
+    -> DependencyCache
+    -> DependencyCache
+  insertFacts i is (DependencyCache df) = DependencyCache $ M.insert i is df
 
   -- | A type of a list of known resources.
   --

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -126,7 +126,7 @@ module Hexyll.Core.Dependencies.Internal where
     -> [Identifier]
     -> DependencyCache
     -> DependencyCache
-  insertFacts i is (DependencyCache df) = DependencyCache $ M.insert i is df
+  insertCache i is (DependencyCache df) = DependencyCache $ M.insert i is df
 
   -- | A type of a list of known resources.
   --

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -231,7 +231,7 @@ module Hexyll.Core.Dependencies.Internal where
   askLookupFacts :: Identifier -> DependencyM [Dependency]
   askLookupFacts i = do
     facts <- askFacts
-    return $ fromMaybe [] $ M.lookup i $ unDependencyFacts facts
+    return $ fromMaybe [] $ lookupFacts i facts
 
   -- | Ask the 'IdentifierUniverse' on 'DependencyM'.
   --
@@ -253,7 +253,7 @@ module Hexyll.Core.Dependencies.Internal where
   askLookupOldCache :: Identifier -> DependencyM (Maybe [Identifier])
   askLookupOldCache i = do
     dc <- askOldCache
-    return $ M.lookup i $ unDependencyCache dc
+    return $ lookupCache i dc
 
   -- | Get a new 'DependencyCache' on 'DependencyM'.
   --
@@ -269,7 +269,7 @@ module Hexyll.Core.Dependencies.Internal where
   getLookupNewCache :: Identifier -> DependencyM (Maybe [Identifier])
   getLookupNewCache i = do
     dc <- getNewCache
-    return $ M.lookup i $ unDependencyCache dc
+    return $ lookupCache i dc
 
   -- | Insert a new key 'Identifier' and value @['Identifier']@ in a new
   -- 'DependencyCache' on 'DependencyM'.
@@ -277,11 +277,8 @@ module Hexyll.Core.Dependencies.Internal where
   -- @since 0.1.0.0
   modifyInsertNewCache :: Identifier -> [Identifier] -> DependencyM ()
   modifyInsertNewCache i is = rws $ \_ s -> case s of
-    DependencyState dc io ->
-      let
-        dc' = DependencyCache $ M.insert i is $ unDependencyCache dc
-      in
-        dc' `seq` ((), DependencyState dc' io, mempty)
+    DependencyState dc io -> let dc' = insertCache i is dc in
+      dc' `seq` ((), DependencyState dc' io, mempty)
 
   -- | Get an 'IdentifierOutOfDate' on 'DependencyM'.
   --

--- a/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Dependencies/Internal.hs
@@ -74,7 +74,7 @@ module Hexyll.Core.Dependencies.Internal where
   -- | Lookup the value at a key in the 'DependencyFacts'.
   --
   -- @since 0.1.0.0
-  lookupFacts :: Identifier -> DependencyFacts -> [Dependency]
+  lookupFacts :: Identifier -> DependencyFacts -> Maybe [Dependency]
   lookupFacts i (DependencyFacts df) = M.lookup i df
 
   -- | Insert a new key and value in the 'DependencyFacts'.
@@ -115,7 +115,7 @@ module Hexyll.Core.Dependencies.Internal where
   -- | Lookup the value at a key in the 'DependencyCache'.
   --
   -- @since 0.1.0.0
-  lookupCache :: Identifier -> DependencyCache -> [Identifier]
+  lookupCache :: Identifier -> DependencyCache -> Maybe [Identifier]
   lookupCache i (DependencyCache df) = M.lookup i df
 
   -- | Insert a new key and value in the 'DependencyCache'.


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/88 .

H.C.Dependencies のユーティリティを追加する。 `emptyFacts` と `lookupFacts` と `insertFacts` と `emptyCache` と `lookupCache` と `insertCache` を追加する。