### PR TITLE
Hexyll.Core.Store を追加する

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -48,7 +48,7 @@ import           Hexyll.Core.Item
 import           Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
 import           Hexyll.Core.Routes
-import qualified Hexyll.Core.Store             as Store
+import qualified Hexyll.Core.OldStore          as Store
 
 import Hexyll.Core.Identifier.Pattern ( fromIdentifier )
 

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -60,7 +60,7 @@ import           Hexyll.Core.Metadata           hiding ( Pattern, unPattern )
 import qualified Hexyll.Core.Metadata as Meta   ( Pattern (..) )
 import           Hexyll.Core.Provider
 import           Hexyll.Core.Routes             hiding ( Pattern, unPattern, match )
-import           Hexyll.Core.Store
+import           Hexyll.Core.OldStore
 
 
 import Data.Typeable ( Typeable )

--- a/hexyll-core/src/Hexyll/Core/Compiler/Require.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Require.hs
@@ -27,8 +27,8 @@ import           Hexyll.Core.Identifier.Pattern hiding ( Pattern, match )
 import           Hexyll.Core.Item
 import           Hexyll.Core.Metadata           hiding ( Pattern )
 import qualified Hexyll.Core.Metadata as Meta   ( Pattern (..) )
-import           Hexyll.Core.Store              (Store)
-import qualified Hexyll.Core.Store              as Store
+import           Hexyll.Core.OldStore           (Store)
+import qualified Hexyll.Core.OldStore           as Store
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -28,7 +28,7 @@ import           Hexyll.Core.Compiler.Internal
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Item
 import           Hexyll.Core.Provider
-import qualified Hexyll.Core.Store             as Store
+import qualified Hexyll.Core.OldStore          as Store
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Writable
 

--- a/hexyll-core/src/Hexyll/Core/OldStore.hs
+++ b/hexyll-core/src/Hexyll/Core/OldStore.hs
@@ -2,7 +2,7 @@
 -- | A store for storing and retreiving items
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
-module Hexyll.Core.Store
+module Hexyll.Core.OldStore
     ( Store
     , Result (..)
     , toMaybe

--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -26,7 +26,7 @@ module Hexyll.Core.Provider
 --------------------------------------------------------------------------------
 import qualified Hexyll.Core.Provider.Internal      as Internal
 import qualified Hexyll.Core.Provider.MetadataCache as Internal
-import           Hexyll.Core.Store                  (Store)
+import           Hexyll.Core.OldStore               (Store)
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/Internal.hs
@@ -37,8 +37,8 @@ import           System.FilePath        (addExtension, (</>))
 
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
-import           Hexyll.Core.Store      (Store)
-import qualified Hexyll.Core.Store      as Store
+import           Hexyll.Core.OldStore   (Store)
+import qualified Hexyll.Core.OldStore   as Store
 import           Hexyll.Core.Util.File
 
 

--- a/hexyll-core/src/Hexyll/Core/Provider/MetadataCache.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider/MetadataCache.hs
@@ -12,7 +12,7 @@ import           Hexyll.Core.Identifier
 import           Hexyll.Core.Metadata
 import           Hexyll.Core.Provider.Internal
 import           Hexyll.Core.Provider.Metadata
-import qualified Hexyll.Core.Store             as Store
+import qualified Hexyll.Core.OldStore          as Store
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -34,8 +34,8 @@ import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
 import           Hexyll.Core.Routes
 import           Hexyll.Core.Rules.Internal
-import           Hexyll.Core.Store             (Store)
-import qualified Hexyll.Core.Store             as Store
+import           Hexyll.Core.OldStore             (Store)
+import qualified Hexyll.Core.OldStore             as Store
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Writable
 

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -39,6 +39,6 @@ module Hexyll.Core.Store where
     :: (MonadIO m, MonadReader env m, HasStoreEnv env, Binary a, Typeable a)
     => StoreKey
     -> m (StoreResult a)
-  set sk = do
+  get sk = do
     env <- ask
     liftIO $ storeGet (view storeEnvL env) sk

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -1,4 +1,4 @@
-{-# RankNTypes #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Hexyll.Core.Store where
 

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -4,7 +4,8 @@ module Hexyll.Core.Store where
 
   import Prelude
 
-  import Data.Typeable ( Typeable )
+  import Data.Binary   ( Binary )
+  import Data.Typeable ( Typeable, TypeRep )
 
   import Control.Monad.IO.Class     ( MonadIO, liftIO )
   import Control.Monad.Reader.Class ( MonadReader ( ask ) )

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -1,0 +1,21 @@
+module Hexyll.Core.Log where
+
+  import Prelude
+
+  import Data.Typeable ( Typeable )
+
+  import Control.Monad.IO.Class     ( MonadIO, liftIO )
+  import Control.Monad.Reader.Class ( MonadReader ( ask ) )
+
+  import Lens.Micro        ( Lens' )
+  import Lens.Micro.Extras ( view )
+
+  type StoreKey = [String]
+
+  data StoreResult a = StoreFound a | StoreNotFound | StoreWrongType TypeRep TypeRep
+    deriving (Eq, Show, Typeable)
+
+  data StoreEnv = StoreEnv
+    { storeSet :: !(forall a. (Binary a, Typeable a) => StoreKey -> a -> IO ())
+    , storeGet :: !(forall a. (Binary a, Typeable a) => StoreKey -> IO (StoreResult a))
+    } deriving (Typeable)

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -1,3 +1,5 @@
+{-# RankNTypes #-}
+
 module Hexyll.Core.Store where
 
   import Prelude

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -1,4 +1,4 @@
-module Hexyll.Core.Log where
+module Hexyll.Core.Store where
 
   import Prelude
 

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -22,3 +22,23 @@ module Hexyll.Core.Store where
     { storeSet :: !(forall a. (Binary a, Typeable a) => StoreKey -> a -> IO ())
     , storeGet :: !(forall a. (Binary a, Typeable a) => StoreKey -> IO (StoreResult a))
     } deriving (Typeable)
+
+  class HasStoreEnv env where
+    storeEnvL :: Lens' env StoreEnv
+
+  set
+    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Binary a, Typeable a)
+    => StoreKey
+    -> a
+    -> m ()
+  set sk x = do
+    env <- ask
+    liftIO $ storeSet (view storeEnvL env) sk x
+
+  get
+    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Binary a, Typeable a)
+    => StoreKey
+    -> m (StoreResult a)
+  set sk = do
+    env <- ask
+    liftIO $ storeGet (view storeEnvL env) sk

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -15,19 +15,22 @@ module Hexyll.Core.Store where
 
   type StoreKey = [String]
 
-  data StoreResult a = StoreFound a | StoreNotFound | StoreWrongType TypeRep TypeRep
+  data StoreResult a
+    = StoreFound a
+    | StoreNotFound
+    | StoreWrongType TypeRep
     deriving (Eq, Show, Typeable)
 
   data StoreEnv = StoreEnv
-    { storeSet :: !(forall a. (Binary a, Typeable a) => StoreKey -> a -> IO ())
-    , storeGet :: !(forall a. (Binary a, Typeable a) => StoreKey -> IO (StoreResult a))
-    } deriving (Typeable)
+    { storeSet :: !(forall a. Typeable a => StoreKey -> a -> IO ())
+    , storeGet :: !(forall a. Typeable a => StoreKey -> IO (StoreResult a))
+    } deriving Typeable
 
   class HasStoreEnv env where
     storeEnvL :: Lens' env StoreEnv
 
   set
-    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Binary a, Typeable a)
+    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Typeable a)
     => StoreKey
     -> a
     -> m ()
@@ -36,7 +39,7 @@ module Hexyll.Core.Store where
     liftIO $ storeSet (view storeEnvL env) sk x
 
   get
-    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Binary a, Typeable a)
+    :: (MonadIO m, MonadReader env m, HasStoreEnv env, Typeable a)
     => StoreKey
     -> m (StoreResult a)
   get sk = do

--- a/hexyll-core/src/Hexyll/Core/Store.hs
+++ b/hexyll-core/src/Hexyll/Core/Store.hs
@@ -4,7 +4,6 @@ module Hexyll.Core.Store where
 
   import Prelude
 
-  import Data.Binary   ( Binary )
   import Data.Typeable ( Typeable, TypeRep )
 
   import Control.Monad.IO.Class     ( MonadIO, liftIO )

--- a/hexyll-core/unit-test/Hexyll/Core/StoreTest.hs
+++ b/hexyll-core/unit-test/Hexyll/Core/StoreTest.hs
@@ -16,7 +16,7 @@ import           Test.Tasty.QuickCheck   (testProperty)
 
 
 --------------------------------------------------------------------------------
-import qualified Hexyll.Core.Store       as Store
+import qualified Hexyll.Core.OldStore       as Store
 import           TestSuite.Util
 
 

--- a/hexyll-core/unit-test/TestSuite/Util.hs
+++ b/hexyll-core/unit-test/TestSuite/Util.hs
@@ -28,8 +28,8 @@ import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier
 import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
-import           Hexyll.Core.Store             (Store)
-import qualified Hexyll.Core.Store             as Store
+import           Hexyll.Core.OldStore             (Store)
+import qualified Hexyll.Core.OldStore             as Store
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Item
 

--- a/hexyll-pandoc/test/TestSuite/Util.hs
+++ b/hexyll-pandoc/test/TestSuite/Util.hs
@@ -32,8 +32,8 @@ import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
-import           Hexyll.Core.Store             (Store)
-import qualified Hexyll.Core.Store             as Store
+import           Hexyll.Core.OldStore             (Store)
+import qualified Hexyll.Core.OldStore             as Store
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Item
 

--- a/hexyll/test/Hexyll/Web/Tags/Tests.hs
+++ b/hexyll/test/Hexyll/Web/Tags/Tests.hs
@@ -11,7 +11,7 @@ import           Test.Tasty.HUnit            (Assertion, testCase, (@?=))
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Provider
-import           Hexyll.Core.Store           (Store)
+import           Hexyll.Core.OldStore           (Store)
 import           Hexyll.Web.Tags
 import           TestSuite.Util
 

--- a/hexyll/test/Hexyll/Web/Template/Context/Tests.hs
+++ b/hexyll/test/Hexyll/Web/Template/Context/Tests.hs
@@ -14,7 +14,7 @@ import           Test.Tasty.HUnit            (Assertion, testCase, (@=?))
 import           Hexyll.Core.Compiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Provider
-import           Hexyll.Core.Store           (Store)
+import           Hexyll.Core.OldStore           (Store)
 import           Hexyll.Web.Template.Context
 import           TestSuite.Util
 

--- a/hexyll/test/TestSuite/Util.hs
+++ b/hexyll/test/TestSuite/Util.hs
@@ -32,8 +32,8 @@ import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger
 import           Hexyll.Core.Provider
-import           Hexyll.Core.Store             (Store)
-import qualified Hexyll.Core.Store             as Store
+import           Hexyll.Core.OldStore             (Store)
+import qualified Hexyll.Core.OldStore             as Store
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Item
 


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/97 .
See https://github.com/Hexirp/hexirp-hakyll/issues/98 .

Hexyll.Core.Store を追加する。まだ設計が定まっておらず、簡単な定義だけ置いて先送りすることになった。