### PR TITLE
Hexyll.Core.Identifier.Pattern のテストをちょっと記述する

### DIFF
--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -12,4 +12,11 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
     describe "fromString @PatternExpr" $ do
 
       it "normally works" $ do
-        True `shouldBe` True
+        fromString "index.md" `shouldBe` fromGlob "index.md"
+
+    describe "matchExpr" $ do
+
+      describe "and fromGlob" $ do
+
+        it "nornally works ('index.md' + 'index.md')" $ do
+          matchExpr "index.md" (fromGlob "index.md") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -42,3 +42,9 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "normally works ('foo/bar/alpha.md' with '**/alpha.md')" $ do
           matchExpr "foo/bar/alpha.md" (fromGlob "**/alpha.md") `shouldBe` True
+
+        it "normally works ('alpha.md' with '**/alpha.md')" $ do
+          matchExpr "alpha.md" (fromGlob "**/alpha.md") `shouldBe` False
+
+        it "normally works ('a/b/c/foo.txt' with 'a/**/*.txt')" $ do
+          matchExpr "a/b/c/foo.txt" (fromGlob "a/**/*.txt") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -34,6 +34,9 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
         it "normally works ('index.md' with '*')" $ do
           matchExpr "index.md" (fromGlob "*") `shouldBe` True
 
+        it "normally works ('foo/index.md' with '*')" $ do
+          matchExpr "foo/index.md" (fromGlob "*") `shouldBe` False
+
         it "normally works ('foo/index.md' with '*/*.md')" $ do
           matchExpr "foo/index.md" (fromGlob "*/*.md") `shouldBe` True
 

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -24,3 +24,18 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "nornally works ('index.md' with 'index.md')" $ do
           matchExpr "index.md" (fromGlob "index.md") `shouldBe` True
+
+        it "normally works ('index.md' with 'ind*.md')" $ do
+          matchExpr "index.md" (fromGlob "ind*.md") `shouldBe` True
+
+        it "normally works ('index.md' with 'assert.md')" $ do
+          matchExpr "index.md" (fromGlob "assert.md") `shouldBe` False
+
+        it "normally works ('index.md' with '*')" $ do
+          matchExpr "index.md" (fromGlob "*") `shouldBe` False
+
+        it "normally works ('foo/index.md' with '*/*.md')" $ do
+          matchExpr "foo/index.md" (fromGlob "*/*.md") `shouldBe` True
+
+        it "normally works ('foo/bar/alpha.md' with '**/alpha.md')" $ do
+          matchExpr "foo/bar/alpha.md" (fromGlob "**/alpha.md") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -32,7 +32,7 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
           matchExpr "index.md" (fromGlob "assert.md") `shouldBe` False
 
         it "normally works ('index.md' with '*')" $ do
-          matchExpr "index.md" (fromGlob "*") `shouldBe` False
+          matchExpr "index.md" (fromGlob "*") `shouldBe` True
 
         it "normally works ('foo/index.md' with '*/*.md')" $ do
           matchExpr "foo/index.md" (fromGlob "*/*.md") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -67,6 +67,23 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
       describe "and (.&&.)" $ do
 
-        it "normally works (everything .&&. everything)" $ do
-          property $ let p = everything .&&. everything in \s ->
+        it "normally works (everything .&&. nothing)" $ do
+          property $ let p = everything .&&. nothing in \s ->
+            matchExpr (fromString s) p == False
+
+      describe "and nothing" $ do
+
+        it "normally works" $ do
+          property $ \s -> matchExpr (fromString s) nothing == False
+
+      describe "and (.||.)" $ do
+
+        it "Normally works (everything .||. nothing)" $ do
+          property $ let p = everything .||. nothing in \s ->
             matchExpr (fromString s) p == True
+
+      describe "and complement" $ do
+
+        it "normally works (complement everything)" $ do
+          property $ let p = complement everything in \s ->
+            matchExpr (fromString s) p = False

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -7,6 +7,7 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
   import Data.String ( IsString (..) )
 
   import Test.Hspec
+  import Test.QuickCheck
 
   import Hexyll.Core.Identifier.Pattern
 

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Hexyll.Core.Identifier.PatternSpec (spec) where
 
   import Prelude

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -7,7 +7,7 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
   import Data.String ( IsString (..) )
 
   import Test.Hspec
-  import Test.QuickCheck
+  import Test.QuickCheck hiding ( (.&&.), (.||.) )
 
   import Hexyll.Core.Identifier.Pattern
 

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -44,7 +44,7 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
           matchExpr "foo/bar/alpha.md" (fromGlob "**/alpha.md") `shouldBe` True
 
         it "normally works ('alpha.md' with '**/alpha.md')" $ do
-          matchExpr "alpha.md" (fromGlob "**/alpha.md") `shouldBe` False
+          matchExpr "alpha.md" (fromGlob "**/alpha.md") `shouldBe` True
 
         it "normally works ('a/b/c/foo.txt' with 'a/**/*.txt')" $ do
           matchExpr "a/b/c/foo.txt" (fromGlob "a/**/*.txt") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -58,3 +58,14 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "normally works ('index.md' with Nothing)" $ do
           matchExpr "index.md" (fromVersion Nothing) `shouldBe` True
+
+      describe "and everything" $ do
+
+        it "normally works" $ do
+          property $ \s -> matchExpr (fromString s) everything == True
+
+      describe "and (.&&.)" $ do
+
+        it "normally works (everything .&&. everything)" $ do
+          property $ let p = everything .&&. everything in \s ->
+            matchExpr (fromString s) p == True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -53,3 +53,8 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "normally works ('index.md' with 'index.md')" $ do
           matchExpr "index.md" (fromRegex "index.md") `shouldBe` True
+
+      describe "and fromVersion" $ do
+
+        it "normally works ('index.md' with Nothing)" $ do
+          matchExpr "index.md" (fromVersion Nothing) `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -1,0 +1,15 @@
+module Hexyll.Core.Identifier.PatternSpec (spec) where
+
+  import Prelude
+
+  import Test.Hspec
+
+  import Hexyll.Core.Identifier.Pattern
+
+  spec :: Spec
+  spec = do
+
+    describe "fromString @PatternExpr" $ do
+
+      it "normally works" $ do
+        True `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -4,6 +4,8 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
   import Prelude
 
+  import Data.String ( IsString (..) )
+
   import Test.Hspec
 
   import Hexyll.Core.Identifier.Pattern

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -48,3 +48,8 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "normally works ('a/b/c/foo.txt' with 'a/**/*.txt')" $ do
           matchExpr "a/b/c/foo.txt" (fromGlob "a/**/*.txt") `shouldBe` True
+
+      describe "and fromRegex" $ do
+
+        it "normally works ('index.md' with 'index.md')" $ do
+          matchExpr "index.md" (fromRegex "index.md") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -18,5 +18,5 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
       describe "and fromGlob" $ do
 
-        it "nornally works ('index.md' + 'index.md')" $ do
+        it "nornally works ('index.md' with 'index.md')" $ do
           matchExpr "index.md" (fromGlob "index.md") `shouldBe` True

--- a/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
+++ b/hexyll-core/test/Hexyll/Core/Identifier/PatternSpec.hs
@@ -86,4 +86,4 @@ module Hexyll.Core.Identifier.PatternSpec (spec) where
 
         it "normally works (complement everything)" $ do
           property $ let p = complement everything in \s ->
-            matchExpr (fromString s) p = False
+            matchExpr (fromString s) p == False


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/71 .

Hexyll.Core.Identifier.Pattern のテストをちょっと記述する。最初はもっと詳細に書く予定だったけど、あまり意義があるとは思えないのでやめる。