### PR TITLE
Hexyll.Core.Metadata をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -195,10 +195,12 @@ instance Applicative Compiler where
 
 
 --------------------------------------------------------------------------------
+instance MonadUniverse Compiler where
+    getMatches (Meta.Pattern p) = compilerGetMatches (Pattern p)
+
 -- | Access provided metadata from anywhere
 instance MonadMetadata Compiler where
     getMetadata = compilerGetMetadata
-    getMatches (Meta.Pattern p) = compilerGetMatches (Pattern p)
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -67,7 +67,7 @@ lookupStringList key (Metadata meta) =
 
 
 
-class MonadiUniverse m => MonadMetadata m where
+class MonadUniverse m => MonadMetadata m where
 
   getMetadata :: Identifier -> m Metadata
 

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -14,10 +14,14 @@ module Hexyll.Core.Metadata where
   import Hexyll.Core.Identifier
   import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
 
+  -- | A type of patterns for 'MonadMetadata'.
+  --
+  -- @since 0.1.0.0
   newtype Pattern = Pattern
     { unPattern :: PatternExpr
     } deriving ( Eq, Ord, Show, Typeable )
 
+  -- | @since 0.1.0.0
   instance IsString Pattern where
     fromString s = Pattern $ fromString s
 

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -47,16 +47,22 @@ module Hexyll.Core.Metadata where
     countUniverse :: m Int
     countUniverse = length <$> getMatches (Pattern everything)
 
+  -- | Metadata associated with identifiers.
+  --
+  -- @since 0.1.0.0
   newtype Metadata = Metadata
     { unMetadata :: Yaml.Object
     } deriving ( Eq, Show, Typeable )
 
+  -- | @since 0.1.0.0
   instance Semigroup Metadata where
     Metadata x <> Metadata y = Metadata (x <> y)
 
+  -- | @since 0.1.0.0
   instance Monoid Metadata where
     mempty = Metadata mempty
 
+  -- | @since 0.1.0.0
   instance Binary Metadata where
     put (Metadata x) = put $ Yaml.BinaryValue $ Yaml.Object x
     get = do
@@ -67,16 +73,30 @@ module Hexyll.Core.Metadata where
         _ ->
           error "Data.Binary.get: Invalid Metadata"
 
+  -- @since 0.1.0.0
   instance Yaml.ToJSON Metadata where
     toJSON (Metadata x) = Yaml.toJSON x
 
+  -- @since 0.1.0.0
   instance Yaml.FromJSON Metadata where
     parseJSON v = Metadata <$> Yaml.parseJSON v
 
+  -- Look up the field corresponding to the key and convert it to a string.
+  -- Returns @Nothing@ if the field cannot be converted to a string.
+  --
+  -- See 'Yaml.toString'.
+  --
+  -- @since 0.1.0.0
   lookupString :: String -> Metadata -> Maybe String
   lookupString key (Metadata meta) =
     HM.lookup (T.pack key) meta >>= Yaml.toString
 
+  -- Look up the field corresponding to the key and convert it to a list of
+  -- strings. If there is at least one failure, Nothing is returned.
+  --
+  -- See 'Yaml.toList' and 'Yaml.toString'.
+  --
+  -- @since 0.1.0.0
   lookupStringList :: String -> Metadata -> Maybe [String]
   lookupStringList key (Metadata meta) =
       HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -1,89 +1,89 @@
 module Hexyll.Core.Metadata where
 
-import Data.Binary   ( Binary (..) )
-import Data.Typeable ( Typeable )
-import Data.String ( IsString (..) )
+  import Data.Binary   ( Binary (..) )
+  import Data.Typeable ( Typeable )
+  import Data.String ( IsString (..) )
 
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Text           as T
-import qualified Data.Yaml           as Yaml
-import qualified Data.Yaml.Hexyll    as Yaml
+  import qualified Data.HashMap.Strict as HM
+  import qualified Data.Text           as T
+  import qualified Data.Yaml           as Yaml
+  import qualified Data.Yaml.Hexyll    as Yaml
 
-import Control.Monad ( forM )
+  import Control.Monad ( forM )
 
-import Hexyll.Core.Identifier
-import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
+  import Hexyll.Core.Identifier
+  import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
 
-newtype Pattern = Pattern
-  { unPattern :: PatternExpr
-  } deriving ( Eq, Ord, Show, Typeable )
+  newtype Pattern = Pattern
+    { unPattern :: PatternExpr
+    } deriving ( Eq, Ord, Show, Typeable )
 
-instance IsString Pattern where
-  fromString s = Pattern $ fromString s
+  instance IsString Pattern where
+    fromString s = Pattern $ fromString s
 
-class Monad m => MonadUniverse m where
+  class Monad m => MonadUniverse m where
 
-  getMatches :: Pattern -> m [Identifier]
+    getMatches :: Pattern -> m [Identifier]
 
-  countUniverse :: m Int
-  countUniverse = length <$> getMatches (Pattern everything)
+    countUniverse :: m Int
+    countUniverse = length <$> getMatches (Pattern everything)
 
-newtype Metadata = Metadata
-  { unMetadata :: Yaml.Object
-  } deriving ( Eq, Show, Typeable )
+  newtype Metadata = Metadata
+    { unMetadata :: Yaml.Object
+    } deriving ( Eq, Show, Typeable )
 
-instance Semigroup Metadata where
-  Metadata x <> Metadata y = Metadata (x <> y)
+  instance Semigroup Metadata where
+    Metadata x <> Metadata y = Metadata (x <> y)
 
-instance Monoid Metadata where
-  mempty = Metadata mempty
+  instance Monoid Metadata where
+    mempty = Metadata mempty
 
-instance Binary Metadata where
-  put (Metadata x) = put $ Yaml.BinaryValue $ Yaml.Object x
-  get = do
-    Yaml.BinaryValue x' <- get
-    case x' of
-      Yaml.Object x ->
-        return $ Metadata x
-      _ ->
-        error "Data.Binary.get: Invalid Metadata"
+  instance Binary Metadata where
+    put (Metadata x) = put $ Yaml.BinaryValue $ Yaml.Object x
+    get = do
+      Yaml.BinaryValue x' <- get
+      case x' of
+        Yaml.Object x ->
+          return $ Metadata x
+        _ ->
+          error "Data.Binary.get: Invalid Metadata"
 
-instance Yaml.ToJSON Metadata where
-  toJSON (Metadata x) = Yaml.toJSON x
+  instance Yaml.ToJSON Metadata where
+    toJSON (Metadata x) = Yaml.toJSON x
 
-instance Yaml.FromJSON Metadata where
-  parseJSON v = Metadata <$> Yaml.parseJSON v
+  instance Yaml.FromJSON Metadata where
+    parseJSON v = Metadata <$> Yaml.parseJSON v
 
-lookupString :: String -> Metadata -> Maybe String
-lookupString key (Metadata meta) =
-  HM.lookup (T.pack key) meta >>= Yaml.toString
+  lookupString :: String -> Metadata -> Maybe String
+  lookupString key (Metadata meta) =
+    HM.lookup (T.pack key) meta >>= Yaml.toString
 
-lookupStringList :: String -> Metadata -> Maybe [String]
-lookupStringList key (Metadata meta) =
-    HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
+  lookupStringList :: String -> Metadata -> Maybe [String]
+  lookupStringList key (Metadata meta) =
+      HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
 
-class MonadUniverse m => MonadMetadata m where
+  class MonadUniverse m => MonadMetadata m where
 
-  getMetadata :: Identifier -> m Metadata
+    getMetadata :: Identifier -> m Metadata
 
-  getAllMetadata :: Pattern -> m [(Identifier, Metadata)]
-  getAllMetadata p = do
-    is <- getMatches p
-    forM is $ \i -> do
-      m <- getMetadata i
-      return (i, m)
+    getAllMetadata :: Pattern -> m [(Identifier, Metadata)]
+    getAllMetadata p = do
+      is <- getMatches p
+      forM is $ \i -> do
+        m <- getMetadata i
+        return (i, m)
 
-getMetadataField :: MonadMetadata m => Identifier -> String -> m (Maybe String)
-getMetadataField identifier key = do
-    metadata <- getMetadata identifier
-    return $ lookupString key metadata
+  getMetadataField :: MonadMetadata m => Identifier -> String -> m (Maybe String)
+  getMetadataField identifier key = do
+      metadata <- getMetadata identifier
+      return $ lookupString key metadata
 
--- | Version of 'getMetadataField' which throws an error if the field does not
--- exist.
-getMetadataField' :: MonadMetadata m => Identifier -> String -> m String
-getMetadataField' identifier key = do
-    field <- getMetadataField identifier key
-    case field of
-        Just v  -> return v
-        Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
-            "Item " ++ show identifier ++ " has no metadata field " ++ show key
+  -- | Version of 'getMetadataField' which throws an error if the field does not
+  -- exist.
+  getMetadataField' :: MonadMetadata m => Identifier -> String -> m String
+  getMetadataField' identifier key = do
+      field <- getMetadataField identifier key
+      case field of
+          Just v  -> return v
+          Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
+              "Item " ++ show identifier ++ " has no metadata field " ++ show key

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -1,3 +1,14 @@
+-- |
+-- Module:      Hexyll.Core.Metadata
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides two type classes 'MonadUniverse' and 'MonadMetadata'.
+--
+-- @since 0.1.0.0
 module Hexyll.Core.Metadata where
 
   import Data.Binary   ( Binary (..) )

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -54,18 +54,13 @@ instance Yaml.ToJSON Metadata where
 instance Yaml.FromJSON Metadata where
   parseJSON v = Metadata <$> Yaml.parseJSON v
 
---------------------------------------------------------------------------------
 lookupString :: String -> Metadata -> Maybe String
 lookupString key (Metadata meta) =
   HM.lookup (T.pack key) meta >>= Yaml.toString
 
-
---------------------------------------------------------------------------------
 lookupStringList :: String -> Metadata -> Maybe [String]
 lookupStringList key (Metadata meta) =
     HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
-
-
 
 class MonadUniverse m => MonadMetadata m where
 
@@ -78,15 +73,11 @@ class MonadUniverse m => MonadMetadata m where
       m <- getMetadata i
       return (i, m)
 
-
---------------------------------------------------------------------------------
 getMetadataField :: MonadMetadata m => Identifier -> String -> m (Maybe String)
 getMetadataField identifier key = do
     metadata <- getMetadata identifier
     return $ lookupString key metadata
 
-
---------------------------------------------------------------------------------
 -- | Version of 'getMetadataField' which throws an error if the field does not
 -- exist.
 getMetadataField' :: MonadMetadata m => Identifier -> String -> m String
@@ -96,5 +87,3 @@ getMetadataField' identifier key = do
         Just v  -> return v
         Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
             "Item " ++ show identifier ++ " has no metadata field " ++ show key
-
-

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -99,7 +99,7 @@ module Hexyll.Core.Metadata where
   -- @since 0.1.0.0
   lookupStringList :: String -> Metadata -> Maybe [String]
   lookupStringList key (Metadata meta) =
-      HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
+    HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
 
   class MonadUniverse m => MonadMetadata m where
 
@@ -114,15 +114,15 @@ module Hexyll.Core.Metadata where
 
   getMetadataField :: MonadMetadata m => Identifier -> String -> m (Maybe String)
   getMetadataField identifier key = do
-      metadata <- getMetadata identifier
-      return $ lookupString key metadata
+    metadata <- getMetadata identifier
+    return $ lookupString key metadata
 
   -- | Version of 'getMetadataField' which throws an error if the field does not
   -- exist.
   getMetadataField' :: MonadMetadata m => Identifier -> String -> m String
   getMetadataField' identifier key = do
-      field <- getMetadataField identifier key
-      case field of
-          Just v  -> return v
-          Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
-              "Item " ++ show identifier ++ " has no metadata field " ++ show key
+    field <- getMetadataField identifier key
+    case field of
+      Just v  -> return v
+      Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
+        "Item " ++ show identifier ++ " has no metadata field " ++ show key

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -25,10 +25,25 @@ module Hexyll.Core.Metadata where
   instance IsString Pattern where
     fromString s = Pattern $ fromString s
 
+  -- | Monads that has a set of identifiers and can search for them.
+  --
+  -- @since 0.1.0.0
   class Monad m => MonadUniverse m where
 
+    -- | Get identifiers that matches the pattern.
+    --
+    -- @since 0.1.0.0
     getMatches :: Pattern -> m [Identifier]
 
+    -- | Get all identifiers.
+    --
+    -- @since 0.1.0.0
+    getAllIdentifier :: m [Identifier]
+    getAllIdentifier = getMatches (Pattern everything)
+
+    -- | Count the number of all identifiers.
+    --
+    -- @since 0.1.0.0
     countUniverse :: m Int
     countUniverse = length <$> getMatches (Pattern everything)
 

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -1,8 +1,5 @@
---------------------------------------------------------------------------------
 module Hexyll.Core.Metadata where
 
-
---------------------------------------------------------------------------------
 import Data.Binary   ( Binary (..) )
 import Data.Typeable ( Typeable )
 import Data.String ( IsString (..) )
@@ -17,7 +14,20 @@ import Control.Monad ( forM )
 import Hexyll.Core.Identifier
 import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
 
---------------------------------------------------------------------------------
+newtype Pattern = Pattern
+  { unPattern :: PatternExpr
+  } deriving ( Eq, Ord, Show, Typeable )
+
+instance IsString Pattern where
+  fromString s = Pattern $ fromString s
+
+instance Monad m => MonadUniverse m where
+
+  getMaches :: Pattern -> m [Identifier]
+
+  countUniverse :: m Int
+  countUniverse = length <$> getMaches (Pattern everything)
+
 newtype Metadata = Metadata
   { unMetadata :: Yaml.Object
   } deriving ( Eq, Show, Typeable )
@@ -56,17 +66,10 @@ lookupStringList key (Metadata meta) =
     HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
 
 
-newtype Pattern = Pattern
-  { unPattern :: PatternExpr
-  } deriving ( Eq, Ord, Show, Typeable )
 
-instance IsString Pattern where
-  fromString s = Pattern $ fromString s
-
-class Monad m => MonadMetadata m where
+class MonadiUniverse m => MonadMetadata m where
 
   getMetadata :: Identifier -> m Metadata
-  getMatches  :: Pattern -> m [Identifier]
 
   getAllMetadata :: Pattern -> m [(Identifier, Metadata)]
   getAllMetadata p = do

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -23,7 +23,7 @@ instance IsString Pattern where
 
 class Monad m => MonadUniverse m where
 
-  getMaches :: Pattern -> m [Identifier]
+  getMatches :: Pattern -> m [Identifier]
 
   countUniverse :: m Int
   countUniverse = length <$> getMaches (Pattern everything)

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -21,7 +21,7 @@ newtype Pattern = Pattern
 instance IsString Pattern where
   fromString s = Pattern $ fromString s
 
-instance Monad m => MonadUniverse m where
+class Monad m => MonadUniverse m where
 
   getMaches :: Pattern -> m [Identifier]
 

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -109,9 +109,9 @@ module Hexyll.Core.Metadata where
     -- | Get the metadata corresponding to the identifier.
     getMetadata :: Identifier -> m Metadata
 
-    -- | Get all metadata in key-value format.
-    getAllMetadata :: Pattern -> m [(Identifier, Metadata)]
-    getAllMetadata p = do
+    -- | Get metadata that matches the pattern in key-value format.
+    getMetadataMatches :: Pattern -> m [(Identifier, Metadata)]
+    getMetadataMatches p = do
       is <- getMatches p
       forM is $ \i -> do
         m <- getMetadata i

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -116,13 +116,3 @@ module Hexyll.Core.Metadata where
   getMetadataField identifier key = do
     metadata <- getMetadata identifier
     return $ lookupString key metadata
-
-  -- | Version of 'getMetadataField' which throws an error if the field does not
-  -- exist.
-  getMetadataField' :: MonadMetadata m => Identifier -> String -> m String
-  getMetadataField' identifier key = do
-    field <- getMetadataField identifier key
-    case field of
-      Just v  -> return v
-      Nothing -> fail $ "Hexyll.Core.Metadata.getMetadataField': " ++
-        "Item " ++ show identifier ++ " has no metadata field " ++ show key

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -26,7 +26,7 @@ class Monad m => MonadUniverse m where
   getMatches :: Pattern -> m [Identifier]
 
   countUniverse :: m Int
-  countUniverse = length <$> getMaches (Pattern everything)
+  countUniverse = length <$> getMatches (Pattern everything)
 
 newtype Metadata = Metadata
   { unMetadata :: Yaml.Object

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -117,7 +117,9 @@ module Hexyll.Core.Metadata where
         m <- getMetadata i
         return (i, m)
 
-  getMetadataField :: MonadMetadata m => Identifier -> String -> m (Maybe String)
+  getMetadataField
+    :: MonadMetadata m
+    => Identifier -> String -> m (Maybe String)
   getMetadataField identifier key = do
     metadata <- getMetadata identifier
     return $ lookupString key metadata

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -101,10 +101,15 @@ module Hexyll.Core.Metadata where
   lookupStringList key (Metadata meta) =
     HM.lookup (T.pack key) meta >>= Yaml.toList >>= mapM Yaml.toString
 
+  -- | Monads that can get metadata.
+  --
+  -- @since 0.1.0.0
   class MonadUniverse m => MonadMetadata m where
 
+    -- | Get the metadata corresponding to the identifier.
     getMetadata :: Identifier -> m Metadata
 
+    -- | Get all metadata in key-value format.
     getAllMetadata :: Pattern -> m [(Identifier, Metadata)]
     getAllMetadata p = do
       is <- getMatches p

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -117,6 +117,11 @@ module Hexyll.Core.Metadata where
         m <- getMetadata i
         return (i, m)
 
+  -- Get the metadata that corresponding to the identifier, look up the field
+  -- corresponding to the key, and convert it to a string. Returns @Nothing@
+  -- if the field cannot be converted to a string.
+  --
+  -- @since 0.1.0.0
   getMetadataField
     :: MonadMetadata m
     => Identifier -> String -> m (Maybe String)

--- a/hexyll-core/src/Hexyll/Core/Metadata.hs
+++ b/hexyll-core/src/Hexyll/Core/Metadata.hs
@@ -84,15 +84,15 @@ module Hexyll.Core.Metadata where
         _ ->
           error "Data.Binary.get: Invalid Metadata"
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance Yaml.ToJSON Metadata where
     toJSON (Metadata x) = Yaml.toJSON x
 
-  -- @since 0.1.0.0
+  -- | @since 0.1.0.0
   instance Yaml.FromJSON Metadata where
     parseJSON v = Metadata <$> Yaml.parseJSON v
 
-  -- Look up the field corresponding to the key and convert it to a string.
+  -- | Look up the field corresponding to the key and convert it to a string.
   -- Returns @Nothing@ if the field cannot be converted to a string.
   --
   -- See 'Yaml.toString'.
@@ -102,7 +102,7 @@ module Hexyll.Core.Metadata where
   lookupString key (Metadata meta) =
     HM.lookup (T.pack key) meta >>= Yaml.toString
 
-  -- Look up the field corresponding to the key and convert it to a list of
+  -- | Look up the field corresponding to the key and convert it to a list of
   -- strings. If there is at least one failure, Nothing is returned.
   --
   -- See 'Yaml.toList' and 'Yaml.toString'.
@@ -128,7 +128,7 @@ module Hexyll.Core.Metadata where
         m <- getMetadata i
         return (i, m)
 
-  -- Get the metadata that corresponding to the identifier, look up the field
+  -- | Get the metadata that corresponding to the identifier, look up the field
   -- corresponding to the key, and convert it to a string. Returns @Nothing@
   -- if the field cannot be converted to a string.
   --

--- a/hexyll-core/src/Hexyll/Core/Rules.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules.hs
@@ -141,7 +141,7 @@ match (Pattern pattern) = matchInternal (Pattern pattern) $ getMatches (Meta.Pat
 --------------------------------------------------------------------------------
 matchMetadata :: Pattern -> (Metadata -> Bool) -> Rules () -> Rules ()
 matchMetadata (Pattern pattern) metadataPred = matchInternal (Pattern pattern) $
-    map fst . filter (metadataPred . snd) <$> getAllMetadata (Meta.Pattern $ fromDisj pattern)
+    map fst . filter (metadataPred . snd) <$> getMetadataMatches (Meta.Pattern $ fromDisj pattern)
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
@@ -100,14 +100,15 @@ newtype Rules a = Rules
 
 
 --------------------------------------------------------------------------------
+instance MonadUniverse Rules where
+    getMatches (Meta.Pattern pattern) = Rules $ do
+        provider <- rulesProvider <$> ask
+        return $ filter (`matchExpr` pattern) $ resourceList provider
+
 instance MonadMetadata Rules where
     getMetadata identifier = Rules $ do
         provider <- rulesProvider <$> ask
         liftIO $ resourceMetadata provider identifier
-
-    getMatches (Meta.Pattern pattern) = Rules $ do
-        provider <- rulesProvider <$> ask
-        return $ filter (`matchExpr` pattern) $ resourceList provider
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Web/Paginate.hs
+++ b/hexyll/src/Hexyll/Web/Paginate.hs
@@ -62,7 +62,7 @@ paginateEvery n = go
 
 --------------------------------------------------------------------------------
 buildPaginateWith
-    :: MonadMetadata m
+    :: MonadUniverse m
     => ([Identifier] -> m [[Identifier]])  -- ^ Group items into pages
     -> Pattern                             -- ^ Select items to paginate
     -> (PageNumber -> Identifier)          -- ^ Identifiers for the pages

--- a/hexyll/src/Hexyll/Web/Tags.hs
+++ b/hexyll/src/Hexyll/Web/Tags.hs
@@ -127,7 +127,7 @@ getCategory = return . return . takeBaseName . takeDirectory . toFilePath
 
 --------------------------------------------------------------------------------
 -- | Higher-order function to read tags
-buildTagsWith :: MonadMetadata m
+buildTagsWith :: MonadUniverse m
               => (Identifier -> m [String])
               -> Pattern
               -> (String -> Identifier)


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/106 .
See https://github.com/Hexirp/hexirp-hakyll/issues/98 .

Hexyll.Core.Metadata をリファクタリングする。一番大きな変更は MonadMetadata を MonadUniverse と MonadMetadata に分離したことである。その他も手を入れたりした。