### PR TITLE
ProviderEnv を作成する

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -36,9 +36,6 @@ module Hexyll.Core.Provider where
   -- If 'modificationTimeOld' is 'Nothing', it means that the file did not
   -- exist in the previous run.
   --
-  -- If 'modificationTime' is greater than 'modificationTimeOld', it means
-  -- the file is newer than the previous run.
-  --
   -- @since 0.1.0.0
   data ModificationTime = ModificationTime
     { modificationTime    :: !UTCTime

--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -81,6 +81,12 @@ module Hexyll.Core.Provider where
     { runProviderLoad :: m a
     } deriving ( Eq, Ord, Show, Typeable )
 
+  -- | Map over 'ProviderLoad'.
+  --
+  -- @since 0.1.0.0
+  mapProviderLoad :: (m a -> n b) -> ProviderLoad m a -> ProviderLoad n b
+  mapProviderLoad f (ProviderLoad pl) = ProviderLoad (f pl)
+
   -- | Unwrap 'ProviderLoad' and evaluate each action in the structure
   -- from left to right, and collect the results.
   --

--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -23,7 +23,7 @@ module Hexyll.Core.Provider where
 
   import Data.Time ( UTCTime (..) )
 
-  import qualified Data.ByteString as B
+  import qualified Data.ByteString.Lazy as BL
 
   import Hexyll.Core.Store
 
@@ -65,7 +65,7 @@ module Hexyll.Core.Provider where
   -- | A body of a file.
   --
   -- @since 0.1.0.0
-  newtype Body = Body { unBody :: B.ByteString }
+  newtype Body = Body { unBody :: BL.ByteString }
     deriving ( Eq, Ord, Show, Typeable )
 
   -- | @since 0.1.0.0

--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -21,6 +21,8 @@ module Hexyll.Core.Provider where
 
   import Data.Maybe ( isJust )
 
+  import qualified Data.Set as S
+
   import Data.Time ( UTCTime (..) )
 
   import qualified Data.ByteString.Lazy as BL
@@ -98,13 +100,13 @@ module Hexyll.Core.Provider where
     -- | Get all paths.
     --
     -- @since 0.1.0.0
-    getAllPath :: m [Path Rel File]
+    getAllPath :: m (S.Set (Path Rel File))
 
     -- | Count all paths.
     --
     -- @since 0.1.0.0
     countAllPath :: m Int
-    countAllPath = length <$> getAllPath
+    countAllPath = S.size <$> getAllPath
 
     -- | Get the modification time of a file lazily.
     --

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -28,8 +28,14 @@ module Hexyll.Core.ProviderEnv where
   import Hexyll.Core.StoreEnv
   import Hexyll.Core.Provider
 
+  -- | A short alias for 'ModificationTime'.
+  --
+  -- @since 0.1.0.0
   type MTime = ModificationTime
 
+  -- | The type of environment for handling a provider.
+  --
+  -- @since 0.1.0.0
   data ProviderEnv = ProviderEnv
     { providerGetAllPath
         :: !(StoreEnv -> IO (S.Set (Path Rel File)))
@@ -41,16 +47,24 @@ module Hexyll.Core.ProviderEnv where
         :: !StoreEnv
     }
 
+  -- | @since 0.1.0.0
   instance HasStoreEnv ProviderEnv where
     storeEnvL =
       lens providerStore (\env store -> env { providerStore = store })
 
+  -- | Environment values with functions handling a provider.
+  --
+  -- @since 0.1.0.0
   class HasProviderEnv env where
     providerEnvL :: Lens' env ProviderEnv
 
+  -- | @since 0.1.0.0
   instance HasProviderEnv ProviderEnv where
     providerEnvL = id
 
+  -- | Get all paths.
+  --
+  -- @since 0.1.0.0
   getAllPathE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => m (S.Set (Path Rel File))
@@ -60,6 +74,9 @@ module Hexyll.Core.ProviderEnv where
       liftIO $
         providerGetAllPath providerEnv (providerStore providerEnv)
 
+  -- | Get the modification time of a file lazily.
+  --
+  -- @since 0.1.0.0
   getModificationTimeDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m ModificationTime))
@@ -70,6 +87,9 @@ module Hexyll.Core.ProviderEnv where
         fmap (fmap (mapProviderLoad liftIO)) $
           providerGetMTimeDelay providerEnv (providerStore providerEnv) p
 
+  -- | Get the body of a file lazily.
+  --
+  -- @since 0.1.0.0
   getBodyDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m Body))

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -1,3 +1,14 @@
+-- |
+-- Module:      Hexyll.Core.ProviderEnv
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides an environment for handling a provider.
+--
+-- @since 0.1.0.0
 module Hexyll.Core.ProviderEnv where
 
   import Prelude

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK show-extensions #-}
+
 -- |
 -- Module:      Hexyll.Core.ProviderEnv
 -- Copyright:   (c) 2019 Hexirp

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -34,3 +34,11 @@ module Hexyll.Core.ProviderEnv where
   getAllPathE = do
     env <- ask
     liftIO $ providerGetAllPath (view providerEnvL env)
+
+  getModificationTimeDelayE
+    :: (MonadIO m, MonadReader env m, HasProviderEnv env)
+    => Path Rel File -> m (Maybe (ProviderLoad m ModificationTime))
+  getModificationTimeDelayE p = do
+    env <- ask
+    liftIO $ fmap (fmap _) $
+      providerGetModificationTimeDelay (view providerEnvL env) p

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -1,0 +1,7 @@
+module Hexyll.Core.ProviderEnv where
+
+  import Prelude
+
+  import Hexyll.Core.Provider
+
+  data ProviderEnv = ProviderEnv

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -42,3 +42,11 @@ module Hexyll.Core.ProviderEnv where
     env <- ask
     liftIO $ fmap (fmap (mapProviderLoad liftIO)) $
       providerGetModificationTimeDelay (view providerEnvL env) p
+
+  getBodyDelayE
+    :: (MonadIO m, MonadReader env m, HasProviderEnv env)
+    => Path Rel File -> m (Maybe (ProviderLoad m Body))
+  getBodyDelayE p = do
+    env <- ask
+    liftIO $ fmap (fmap (mapProviderLoad liftIO)) $
+      providerGetBodyDelay (view providerEnvL env) p

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -2,6 +2,16 @@ module Hexyll.Core.ProviderEnv where
 
   import Prelude
 
+  import qualified Data.Set as S
+
+  import Path
+
   import Hexyll.Core.Provider
 
   data ProviderEnv = ProviderEnv
+    { providerGetAllPath :: IO (S.Set (Path Rel File))
+    , providerGetModificationTimeDelay
+        :: Path Rel File -> IO (Maybe (ProviderLoad IO ModificationTime))
+    , providerGetBodyDelay
+        :: Path Rel File -> IO (Maybe (ProviderLoad IO Body))
+    }

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -2,6 +2,9 @@ module Hexyll.Core.ProviderEnv where
 
   import Prelude
 
+  import Control.Monad.IO.Class     ( MonadIO, liftIO )
+  import Control.Monad.Reader.Class ( MonadReader ( ask ) )
+
   import Lens.Micro        ( Lens' )
   import Lens.Micro.Extras ( view )
 
@@ -25,5 +28,9 @@ module Hexyll.Core.ProviderEnv where
   instance HasProviderEnv ProviderEnv where
     providerEnvL = id
 
-  getAllPathE :: ()
-  getAllPathE = ()
+  getAllPathE
+    :: (MonadIO m, MonadReader env m, HasProviderEnv env)
+    => m (S.Set (Path Rel File))
+  getAllPathE = do
+    env <- ask
+    liftIO $ providerGetAllPath (view providerEnvL env)

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -5,7 +5,7 @@ module Hexyll.Core.ProviderEnv where
   import Control.Monad.IO.Class     ( MonadIO, liftIO )
   import Control.Monad.Reader.Class ( MonadReader ( ask ) )
 
-  import Lens.Micro        ( Lens' )
+  import Lens.Micro        ( Lens', lens )
   import Lens.Micro.Extras ( view )
 
   import qualified Data.Set as S
@@ -27,6 +27,10 @@ module Hexyll.Core.ProviderEnv where
     , providerStore
         :: StoreEnv
     }
+
+  instance HasStoreEnv ProviderEnv where
+    storeEnvL =
+      lens providerStore (\env store -> env { providerStore = store })
 
   class HasProviderEnv env where
     providerEnvL :: Lens' env ProviderEnv

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -40,5 +40,5 @@ module Hexyll.Core.ProviderEnv where
     => Path Rel File -> m (Maybe (ProviderLoad m ModificationTime))
   getModificationTimeDelayE p = do
     env <- ask
-    liftIO $ fmap (fmap _) $
+    liftIO $ fmap (fmap (mapProviderLoad liftIO)) $
       providerGetModificationTimeDelay (view providerEnvL env) p

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -12,14 +12,20 @@ module Hexyll.Core.ProviderEnv where
 
   import Path
 
+  import Hexyll.Core.StoreEnv
   import Hexyll.Core.Provider
 
+  type MTime = ModificationTime
+
   data ProviderEnv = ProviderEnv
-    { providerGetAllPath :: IO (S.Set (Path Rel File))
-    , providerGetModificationTimeDelay
-        :: Path Rel File -> IO (Maybe (ProviderLoad IO ModificationTime))
+    { providerGetAllPath
+        :: StoreEnv -> IO (S.Set (Path Rel File))
+    , providerGetMTimeDelay
+        :: StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO MTime))
     , providerGetBodyDelay
-        :: Path Rel File -> IO (Maybe (ProviderLoad IO Body))
+        :: StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO Body))
+    , providerStore
+        :: StoreEnv
     }
 
   class HasProviderEnv env where
@@ -33,20 +39,23 @@ module Hexyll.Core.ProviderEnv where
     => m (S.Set (Path Rel File))
   getAllPathE = do
     env <- ask
-    liftIO $ providerGetAllPath (view providerEnvL env)
+    liftIO $ let providerEnv = view providerEnvL env in
+      providerGetAllPath providerEnv (providerStore providerEnv)
 
   getModificationTimeDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m ModificationTime))
   getModificationTimeDelayE p = do
     env <- ask
-    liftIO $ fmap (fmap (mapProviderLoad liftIO)) $
-      providerGetModificationTimeDelay (view providerEnvL env) p
+    liftIO $ let providerEnv = view providerEnvL env in
+      fmap (fmap (mapProviderLoad liftIO)) $
+        providerGetMTimeDelay providerEnv (providerStore providerEnv) p
 
   getBodyDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m Body))
   getBodyDelayE p = do
     env <- ask
-    liftIO $ fmap (fmap (mapProviderLoad liftIO)) $
-      providerGetBodyDelay (view providerEnvL env) p
+    liftIO $ let providerEnv = view providerEnvL env in
+      fmap (fmap (mapProviderLoad liftIO)) $
+        providerGetBodyDelay providerEnv (providerStore providerEnv)  p

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -39,23 +39,26 @@ module Hexyll.Core.ProviderEnv where
     => m (S.Set (Path Rel File))
   getAllPathE = do
     env <- ask
-    liftIO $ let providerEnv = view providerEnvL env in
-      providerGetAllPath providerEnv (providerStore providerEnv)
+    let providerEnv = view providerEnvL env in
+      liftIO $
+        providerGetAllPath providerEnv (providerStore providerEnv)
 
   getModificationTimeDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m ModificationTime))
   getModificationTimeDelayE p = do
     env <- ask
-    liftIO $ let providerEnv = view providerEnvL env in
-      fmap (fmap (mapProviderLoad liftIO)) $
-        providerGetMTimeDelay providerEnv (providerStore providerEnv) p
+    let providerEnv = view providerEnvL env in
+      liftIO $
+        fmap (fmap (mapProviderLoad liftIO)) $
+          providerGetMTimeDelay providerEnv (providerStore providerEnv) p
 
   getBodyDelayE
     :: (MonadIO m, MonadReader env m, HasProviderEnv env)
     => Path Rel File -> m (Maybe (ProviderLoad m Body))
   getBodyDelayE p = do
     env <- ask
-    liftIO $ let providerEnv = view providerEnvL env in
-      fmap (fmap (mapProviderLoad liftIO)) $
-        providerGetBodyDelay providerEnv (providerStore providerEnv)  p
+    let providerEnv = view providerEnvL env in
+      liftIO $
+        fmap (fmap (mapProviderLoad liftIO)) $
+          providerGetBodyDelay providerEnv (providerStore providerEnv)  p

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -19,13 +19,13 @@ module Hexyll.Core.ProviderEnv where
 
   data ProviderEnv = ProviderEnv
     { providerGetAllPath
-        :: StoreEnv -> IO (S.Set (Path Rel File))
+        :: !(StoreEnv -> IO (S.Set (Path Rel File)))
     , providerGetMTimeDelay
-        :: StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO MTime))
+        :: !(StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO MTime)))
     , providerGetBodyDelay
-        :: StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO Body))
+        :: !(StoreEnv -> Path Rel File -> IO (Maybe (ProviderLoad IO Body)))
     , providerStore
-        :: StoreEnv
+        :: !StoreEnv
     }
 
   instance HasStoreEnv ProviderEnv where

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -2,6 +2,9 @@ module Hexyll.Core.ProviderEnv where
 
   import Prelude
 
+  import Lens.Micro        ( Lens' )
+  import Lens.Micro.Extras ( view )
+
   import qualified Data.Set as S
 
   import Path
@@ -15,3 +18,12 @@ module Hexyll.Core.ProviderEnv where
     , providerGetBodyDelay
         :: Path Rel File -> IO (Maybe (ProviderLoad IO Body))
     }
+
+  class HasProviderEnv env where
+    providerEnvL :: Lens' env ProviderEnv
+
+  instance HasProviderEnv ProviderEnv where
+    providerEnvL = id
+
+  getAllPathE :: ()
+  getAllPathE = ()

--- a/hexyll-core/src/Hexyll/Core/StoreEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/StoreEnv.hs
@@ -69,6 +69,10 @@ module Hexyll.Core.StoreEnv
   class HasStoreEnv env where
     storeEnvL :: Lens' env StoreEnv
 
+  -- | @since 0.1.0.0
+  instance HasStoreEnv StoreEnv where
+    storeEnvL = id
+
   -- | Save a value with a key.
   --
   -- @since 0.1.0.0


### PR DESCRIPTION
See https://github.com/Hexirp/hexirp-hakyll/issues/98 .
Fix https://github.com/Hexirp/hexirp-hakyll/issues/114 .

ProviderEnv を作成する。これは StoreEnv を内蔵している。このようなものを書くのは初めてだが、型が複雑になってしまう他は何の問題もなく記述できた。それ以外の追加のフィールドはない。 provider ディレクトリの位置などは変更を許すべきではないものであるためフィールドとして追加しなかった。

H.C.Provider にもいくつかの変更を加えた。大きな変更は Body の取得に Lazy な ByteString を使うようにしたことと有効なパス全ての取得の結果を Set にしたことである。