### PR TITLE
BinaryTime に関するものを整備する

### DIFF
--- a/hexyll-core/src/Data/Time/Hexyll.hs
+++ b/hexyll-core/src/Data/Time/Hexyll.hs
@@ -1,3 +1,14 @@
+-- |
+-- Module:      Data.Time.Hexyll
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   unstable
+-- Portability: portable
+--
+-- This module includes types and functions about "Data.Time".
+--
+-- @since 0.1.0.0
 module Data.Time.Hexyll where
 
   import Prelude
@@ -10,12 +21,17 @@ module Data.Time.Hexyll where
 
   import Data.Binary ( Binary (..) )
 
+  -- | A wrapper for the instance @'Binary' 'UTCTime'@.
+  --
+  -- @since 0.1.0.0
   newtype BinaryTime = BinaryTime { unBinaryTime :: UTCTime }
     deriving ( Eq, Ord, Show, Typeable )
 
+  -- | @since 0.1.0.0
   instance NFData BinaryTime where
     rnf (BinaryTime x) = rnf x
 
+  -- | @since 0.1.0.0
   instance Binary BinaryTime where
     put (BinaryTime t) = case t of
       UTCTime (ModifiedJulianDay d) dt -> do

--- a/hexyll-core/src/Data/Time/Hexyll.hs
+++ b/hexyll-core/src/Data/Time/Hexyll.hs
@@ -2,11 +2,19 @@ module Data.Time.Hexyll where
 
   import Prelude
 
+  import Data.Typeable ( Typeable )
+
+  import Control.DeepSeq ( NFData (..) )
+
   import Data.Time
 
   import Data.Binary ( Binary (..) )
 
   newtype BinaryTime = BinaryTime { unBinaryTime :: UTCTime }
+    deriving ( Eq, Ord, Show, Typeable )
+
+  instance NFData BinaryTime where
+    rnf (BinaryTime x) = rnf x
 
   instance Binary BinaryTime where
     put (BinaryTime t) = case t of

--- a/hexyll-core/src/Data/Time/Hexyll.hs
+++ b/hexyll-core/src/Data/Time/Hexyll.hs
@@ -9,5 +9,11 @@ module Data.Time.Hexyll where
   newtype BinaryTime = BinaryTime { unBinaryTime :: UTCTime }
 
   instance Binary BinaryTime where
-    put = undefined
-    get = undefined
+    put (BinaryTime t) = case t of
+      UTCTime (ModifiedJulianDay d) dt -> do
+        put d
+        put (toRational dt)
+    get = do
+      d <- get
+      dt' <- get
+      return (BinaryTime (UTCTime (ModifiedJulianDay d) (fromRational dt')))


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/120 .
See https://github.com/Hexirp/hexirp-hakyll/issues/98 .

BinaryTime に関するものを整備する。 `undefined` を置き換えてドキュメントを書いた。