### PR TITLE
Resourcre を一つのモジュールに独立させる。

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Provider.hs
+++ b/hexyll-core/src/Hexyll/Core/Provider.hs
@@ -25,32 +25,10 @@ module Hexyll.Core.Provider where
 
   import Data.Time ( UTCTime (..) )
 
-  import Data.Binary ( Binary (..) )
-
   import qualified Data.ByteString.Lazy as BL
 
+  import Hexyll.Core.Resource
   import Hexyll.Core.Store
-
-  import Path
-
-  -- | A path of a resource.
-  --
-  -- @since 0.1.0.0
-  data Resource = Resource { unResource :: Path Rel File }
-    deriving ( Eq, Ord, Show, Typeable )
-
-  -- | @since 0.1.0.0
-  instance NFData Resource where
-    rnf (Resource x) = rnf x
-
-  -- | @since 0.1.0.0
-  instance Binary Resource where
-    put (Resource x) = put (toFilePath x)
-    get = do
-      x' <- get
-      case parseRelFile x' of
-        Nothing -> error "Data.Binary.get: Invalid Resource"
-        Just x -> return (Resource x)
 
   -- | A type of modification time.
   --

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -48,6 +48,7 @@ module Hexyll.Core.ProviderEnv
   import System.Directory        ( getModificationTime )
   import System.Directory.Hexyll ( listDirectoryRecursive )
 
+  import Hexyll.Core.Resource
   import Hexyll.Core.Store
   import Hexyll.Core.StoreEnv
   import Hexyll.Core.Provider

--- a/hexyll-core/src/Hexyll/Core/Resource.hs
+++ b/hexyll-core/src/Hexyll/Core/Resource.hs
@@ -1,0 +1,46 @@
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module:      Hexyll.Core.Resource
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module defines 'Resource', a type used to uniquely identify a resource.
+--
+-- @since 0.1.0.0
+module Hexyll.Core.Resource where
+
+  import Prelude
+
+  import Data.Typeable   ( Typeable )
+
+  import Control.DeepSeq ( NFData (..) )
+
+  import Data.Binary ( Binary (..) )
+
+  import Path
+
+  -- | A path of a resource.
+  --
+  -- This type is used to uniquely identify a resource. It is a file path
+  -- under the provider directory.
+  --
+  -- @since 0.1.0.0
+  data Resource = Resource { unResource :: Path Rel File }
+    deriving ( Eq, Ord, Show, Typeable )
+
+  -- | @since 0.1.0.0
+  instance NFData Resource where
+    rnf (Resource x) = rnf x
+
+  -- | @since 0.1.0.0
+  instance Binary Resource where
+    put (Resource x) = put (toFilePath x)
+    get = do
+      x' <- get
+      case parseRelFile x' of
+        Nothing -> error "Data.Binary.get: Invalid Resource"
+        Just x -> return (Resource x)


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/127 .
See https://github.com/Hexirp/hexirp-hakyll/pull/119 .
See https://github.com/Hexirp/hexirp-hakyll/issues/125 .
See https://github.com/Hexirp/hexirp-hakyll/issues/123 .

Resourcre を一つのモジュールに独立させる。 H.C.Resource を H.C.Provider から分離した。それだけである。