### PR TITLE
Universe を H.C.Metadata から独立させる

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Universe.hs
+++ b/hexyll-core/src/Hexyll/Core/Universe.hs
@@ -1,0 +1,62 @@
+-- |
+-- Module:      Hexyll.Core.Universe
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides a type class 'MonadUniverse' for handling the
+-- 'Identifier' set.
+--
+-- @since 0.1.0.0
+module Hexyll.Core.Universe where
+
+  import Data.Binary   ( Binary (..) )
+  import Data.Typeable ( Typeable )
+  import Data.String ( IsString (..) )
+
+  import qualified Data.HashMap.Strict as HM
+  import qualified Data.Text           as T
+  import qualified Data.Yaml           as Yaml
+  import qualified Data.Yaml.Hexyll    as Yaml
+
+  import Control.Monad ( forM )
+
+  import qualified Data.Set as S
+
+  import Hexyll.Core.Identifier
+  import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
+
+  -- | A type of patterns for 'MonadUniverse'.
+  --
+  -- @since 0.1.0.0
+  newtype Pattern = Pattern
+    { unPattern :: PatternExpr
+    } deriving ( Eq, Ord, Show, Typeable )
+
+  -- | @since 0.1.0.0
+  instance IsString Pattern where
+    fromString s = Pattern $ fromString s
+
+  -- | Monads that has a set of identifiers and can search for them.
+  --
+  -- @since 0.1.0.0
+  class Monad m => MonadUniverse m where
+
+    -- | Get identifiers that matches the pattern.
+    --
+    -- @since 0.1.0.0
+    getMatches :: Pattern -> m (S.Set Identifier)
+
+    -- | Get all identifiers.
+    --
+    -- @since 0.1.0.0
+    getAllIdentifier :: m (S.Set Identifier)
+    getAllIdentifier = getMatches (Pattern everything)
+
+    -- | Count the number of all identifiers.
+    --
+    -- @since 0.1.0.0
+    countUniverse :: m Int
+    countUniverse = S.size <$> getMatches (Pattern everything)

--- a/hexyll-core/src/Hexyll/Core/Universe.hs
+++ b/hexyll-core/src/Hexyll/Core/Universe.hs
@@ -12,21 +12,14 @@
 -- @since 0.1.0.0
 module Hexyll.Core.Universe where
 
-  import Data.Binary   ( Binary (..) )
   import Data.Typeable ( Typeable )
+
   import Data.String ( IsString (..) )
-
-  import qualified Data.HashMap.Strict as HM
-  import qualified Data.Text           as T
-  import qualified Data.Yaml           as Yaml
-  import qualified Data.Yaml.Hexyll    as Yaml
-
-  import Control.Monad ( forM )
 
   import qualified Data.Set as S
 
   import Hexyll.Core.Identifier
-  import Hexyll.Core.Identifier.Pattern hiding ( Pattern )
+  import Hexyll.Core.Identifier.Pattern hiding ( Pattern (..) )
 
   -- | A type of patterns for 'MonadUniverse'.
   --

--- a/hexyll-core/src/Hexyll/Core/Universe.hs
+++ b/hexyll-core/src/Hexyll/Core/Universe.hs
@@ -19,7 +19,7 @@ module Hexyll.Core.Universe where
   import qualified Data.Set as S
 
   import Hexyll.Core.Identifier
-  import Hexyll.Core.Identifier.Pattern hiding ( Pattern (..) )
+  import Hexyll.Core.Identifier.Pattern hiding ( Pattern (..), match )
 
   -- | A type of patterns for 'MonadUniverse'.
   --
@@ -31,6 +31,12 @@ module Hexyll.Core.Universe where
   -- | @since 0.1.0.0
   instance IsString Pattern where
     fromString s = Pattern $ fromString s
+
+  -- | Match a 'Identifier' with a 'Pattern'.
+  --
+  -- @since 0.1.0.0
+  match :: Identifier -> Pattern -> Bool
+  match i (Pattern p) = i `matchExpr` p
 
   -- | Monads that has a set of identifiers and can search for them.
   --

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -84,7 +84,7 @@ module Hexyll.Core.UniverseEnv where
   newUniverseEnv :: S.Set Identifier -> IO UniverseEnv
   newUniverseEnv s =
     evaluate $ let i = S.size s in s `seq` i `seq` UniverseEnv
-      { universeMatches = \p -> evaluate $ S.filter (`undefined` p) s
+      { universeMatches = \p -> evaluate $ S.filter (`match` p) s
       , universeAllIdent = return s
       , universeCount = return i
       }

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -23,6 +23,8 @@ module Hexyll.Core.UniverseEnv where
 
   import qualified Data.Set as S
 
+  import Control.Exception ( evaluate )
+
   import Hexyll.Core.Identifier
   import Hexyll.Core.Universe
 
@@ -75,3 +77,13 @@ module Hexyll.Core.UniverseEnv where
   countUniverse = do
     env <- ask
     liftIO $ universeCount (view universeEnvL env)
+
+  -- | Make a new 'UniverseEnv'. It works strictly.
+  --
+  -- @since 0.1.0.0
+  newUniverseEnv :: S.Set Identifier -> IO UniverseEnv
+  newUniverseEnv s = evaluate $ let i = S.size s in i `seq` UniverseEnv
+    { universeMatches = \p -> evaluate $ S.filter (`undefined` p) s
+    , universeAllIdent = evaluate s
+    , universeCount = evaluate i
+    }

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -1,0 +1,77 @@
+-- |
+-- Module:      Hexyll.Core.UniverseEnv
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides an environment for handling the 'Identifier' set.
+--
+-- @since 0.1.0.0
+module Hexyll.Core.UniverseEnv where
+
+  import Prelude
+
+  import Data.Typeable  ( Typeable )
+
+  import Control.Monad.IO.Class     ( MonadIO, liftIO )
+  import Control.Monad.Reader.Class ( MonadReader ( ask ) )
+
+  import Lens.Micro        ( Lens' )
+  import Lens.Micro.Extras ( view )
+
+  import qualified Data.Set as S
+
+  import Hexyll.Core.Identifier
+  import Hexyll.Core.Universe
+
+  -- | The type of environment for handling the 'Identifier' set.
+  --
+  -- @since 0.1.0.0
+  data UniverseEnv = UniverseEnv
+    { universeGetMatches :: !(Pattern -> IO (S.Set Identifier))
+    , universeGetAllIdentifier :: !(IO (S.Set Identifier))
+    , universeCountUniverse :: !(IO Int)
+    } deriving Typeable
+
+  -- | Environment values with an environment for handling the 'Identifier'
+  -- set.
+  --
+  -- @since 0.1.0.0
+  class HasUniverseEnv env where
+    universeEnvL :: Lens' env UniverseEnv
+
+  -- | @since 0.1.0.0
+  instance HasUniverseEnv UniverseEnv where
+    universeEnvL = id
+
+  -- | Get identifiers that matches the pattern.
+  --
+  -- @since 0.1.0.0
+  getMatchesE
+    :: (MonadIO m, MonadReader env m, HasUniverseEnv env)
+    => Pattern -> m (S.Set Identifier)
+  getMatchesE p = do
+    env <- ask
+    liftIO $ universeGetMatches (view universeEnvL env) p
+
+  -- | Get all identifiers.
+  --
+  -- @since 0.1.0.0
+  getAllIdentifier
+    :: (MonadIO m, MonadReader env m, HasUniverseEnv env)
+    => m (S.Set Identifier)
+  getAllIdentifier = do
+    env <- ask
+    liftIO $ universeGetAllIdentifier (view universeEnvL env)
+
+  -- | Count the number of all identifiers.
+  --
+  -- @since 0.1.0.0
+  countUniverse
+    :: (MonadIO m, MonadReader env m, HasUniverseEnv env)
+    => m Int
+  countUniverse = do
+    env <- ask
+    liftIO $ universeCountUniverse (view universeEnvL env)

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -30,9 +30,9 @@ module Hexyll.Core.UniverseEnv where
   --
   -- @since 0.1.0.0
   data UniverseEnv = UniverseEnv
-    { universeGetMatches :: !(Pattern -> IO (S.Set Identifier))
-    , universeGetAllIdentifier :: !(IO (S.Set Identifier))
-    , universeCountUniverse :: !(IO Int)
+    { universeMatches :: !(Pattern -> IO (S.Set Identifier))
+    , universeAllIdent :: !(IO (S.Set Identifier))
+    , universeCount :: !(IO Int)
     } deriving Typeable
 
   -- | Environment values with an environment for handling the 'Identifier'
@@ -54,7 +54,7 @@ module Hexyll.Core.UniverseEnv where
     => Pattern -> m (S.Set Identifier)
   getMatchesE p = do
     env <- ask
-    liftIO $ universeGetMatches (view universeEnvL env) p
+    liftIO $ universeMatches (view universeEnvL env) p
 
   -- | Get all identifiers.
   --
@@ -64,7 +64,7 @@ module Hexyll.Core.UniverseEnv where
     => m (S.Set Identifier)
   getAllIdentifier = do
     env <- ask
-    liftIO $ universeGetAllIdentifier (view universeEnvL env)
+    liftIO $ universeAllIdent (view universeEnvL env)
 
   -- | Count the number of all identifiers.
   --
@@ -74,4 +74,4 @@ module Hexyll.Core.UniverseEnv where
     => m Int
   countUniverse = do
     env <- ask
-    liftIO $ universeCountUniverse (view universeEnvL env)
+    liftIO $ universeCount (view universeEnvL env)

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -82,8 +82,9 @@ module Hexyll.Core.UniverseEnv where
   --
   -- @since 0.1.0.0
   newUniverseEnv :: S.Set Identifier -> IO UniverseEnv
-  newUniverseEnv s = evaluate $ let i = S.size s in i `seq` UniverseEnv
-    { universeMatches = \p -> evaluate $ S.filter (`undefined` p) s
-    , universeAllIdent = evaluate s
-    , universeCount = evaluate i
-    }
+  newUniverseEnv s =
+    evaluate $ let i = S.size s in s `seq` i `seq` UniverseEnv
+      { universeMatches = \p -> evaluate $ S.filter (`undefined` p) s
+      , universeAllIdent = return s
+      , universeCount = return i
+      }


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/132 .

Universe を H.C.Metadata から独立させる。 H.C.Metadata は Application 層で実装するので。また UniverseEnv も作る。