### PR TITLE
Hexyll.Core.Compiler.Internal をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -32,6 +32,13 @@ module Hexyll.Core.Compiler where
       f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
       f3  x3             y3            = fmap (\x' -> f0 x' y3) x3
 
+  instance (Functor s, Monad m) => Monad (Coroutine s m) where
+    x >>= y = f0 x y where
+      f0 (Coroutine x0) y0 = Coroutine (f1 x0 y0)
+      f1 x1 y1 = x1 >>= \x' -> f2 x' y1
+      f2 (Left x2) y2 = pure (Left (fmap (\x' -> f0 x' y2) x2))
+      f2 (Right x2) y2 = unCoroutine (y2 x2)
+
   type Snapshot = String
 
   data CompilerErrors a = CompilerErrors

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -4,6 +4,7 @@ module Hexyll.Core.Compiler where
 
   import Prelude
 
+  import Control.Monad.Trans.Class      ( MonadTrans (..) )
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
 
   import Hexyll.Core.Identifier
@@ -37,6 +38,9 @@ module Hexyll.Core.Compiler where
       f2 :: forall s m a b. (Functor s, Monad m) => Either (s (Coroutine s m a)) a -> (a -> Coroutine s m b) -> m (Either (s (Coroutine s m b)) b)
       f2 (Left  x2) y2 = pure (Left (fmap (flip f0 y2) x2))
       f2 (Right x2) y2 = unCoroutine (y2 x2)
+
+  instance Functor s => MonadTrans (Coroutine s) where
+    lift x = Coroutine (fmap Right x)
 
   type Snapshot = String
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -7,7 +7,7 @@ module Hexyll.Core.Compiler where
   import Hexyll.Core.Identifier
 
   newtype Coroutine s m a = Coroutine
-    { unCoroutine :: m (Either (s (Coroutine s m r)) r)
+    { unCoroutine :: m (Either (s (Coroutine s m a)) a)
     }
 
   type Snapshot = String

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -4,6 +4,7 @@ module Hexyll.Core.Compiler where
 
   import Prelude
 
+  import Control.Monad.IO.Class         ( MonadIO (..) )
   import Control.Monad.Trans.Class      ( MonadTrans (..) )
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
 
@@ -41,6 +42,9 @@ module Hexyll.Core.Compiler where
 
   instance Functor s => MonadTrans (Coroutine s) where
     lift x = Coroutine (fmap Right x)
+
+  instance (Functor s, MonadIO m) => MonadIO (Coroutine s m) where
+    liftIO x = Coroutine (fmap Right (liftIO x))
 
   type Snapshot = String
 
@@ -80,3 +84,6 @@ module Hexyll.Core.Compiler where
 
   instance Monad Compiler where
     x >>= y = Compiler (unCompiler x >>= \x' -> unCompiler (y x'))
+
+  instance MonadIO Compiler where
+    liftIO x = Compiler (liftIO x)

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -26,8 +26,8 @@ module Hexyll.Core.Compiler where
       f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
       f0 x0 y0 = Coroutine (f2 <$> unCoroutine x0 <*> unCoroutine y0)
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b
-      f2 (Left x2 )  y2        = Left (fmap (flip f0 (Coroutine (pure y2))) x2)
-      f2 (Right x2) (Left y2 ) = Left (fmap (fmap x2) y2)
+      f2 (Left  x2)  y2        = Left (fmap (flip f0 (Coroutine (pure y2))) x2)
+      f2 (Right x2) (Left  y2) = Left (fmap (fmap x2) y2)
       f2 (Right x2) (Right y2) = Right (x2 y2)
 
   instance (Functor s, Monad m) => Monad (Coroutine s m) where
@@ -35,7 +35,7 @@ module Hexyll.Core.Compiler where
       f0 :: forall s m a b. (Functor s, Monad m) => Coroutine s m a -> (a -> Coroutine s m b) -> Coroutine s m b
       f0 x0 y0 = Coroutine (unCoroutine x0 >>= flip f2 y0)
       f2 :: forall s m a b. (Functor s, Monad m) => Either (s (Coroutine s m a)) a -> (a -> Coroutine s m b) -> m (Either (s (Coroutine s m b)) b)
-      f2 (Left x2)  y2 = pure (Left (fmap (flip f0 y2) x2))
+      f2 (Left  x2) y2 = pure (Left (fmap (flip f0 y2) x2))
       f2 (Right x2) y2 = unCoroutine (y2 x2)
 
   type Snapshot = String

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -29,13 +29,22 @@ module Hexyll.Core.Compiler where
       f1  x1             y1            = f2 <$> x1 <*> y1
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b
       f2 (Left x2     )  y2            = Left (f3 x2 y2)
-      f2 (Right x2    )  y2            = undefined
+      f2 (Right x2    ) (Left y2     ) = Left (f7 x2 y2)
+      f2 (Right x2    ) (Right y2    ) = Right (f9 x2 y2)
       f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Either (s (Coroutine s m a)) a -> s (Coroutine s m b)
       f3  x3             y3            = f4 x3 (pure y3)
       f4 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> m (Either (s (Coroutine s m a)) a) -> s (Coroutine s m b)
       f4  x4             y4            = f5 x4 (Coroutine y4)
       f5 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
-      f5  x5             y5            = fmap (<*> y5) x5
+      f5  x5             y5            = fmap (\x' -> f6 x' y5) x5
+      f6 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
+      f6  x6             y6            = f0 x6 y6
+      f7 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> s (Coroutine s m a) -> s (Coroutine s m b)
+      f7  x7             y7            = fmap (f8 x7) y7
+      f8 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> Coroutine s m a -> Coroutine s m b
+      f8  x8             y8            = fmap x8 y8
+      f9 :: forall a b. (a -> b) -> a -> b
+      f9  x9             y9            = x9 y9
 
   type Snapshot = String
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Hexyll.Core.Compiler where
 
@@ -7,6 +8,7 @@ module Hexyll.Core.Compiler where
   import Control.Monad.IO.Class         ( MonadIO (..) )
   import Control.Monad.Trans.Class      ( MonadTrans (..) )
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
+  import Control.Monad.Reader.Class     ( MonadReader (..) )
 
   import Lens.Micro        ( lens )
 
@@ -123,3 +125,7 @@ module Hexyll.Core.Compiler where
 
   instance MonadIO Compiler where
     liftIO x = Compiler (liftIO x)
+
+  instance MonadReader CompilerRead Compiler where
+    ask = Compiler ask
+    local f (Compiler x) = Compiler (local f x)

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -46,6 +46,18 @@ module Hexyll.Core.Compiler where
       f9 :: forall a b. (a -> b) -> a -> b
       f9  x9             y9            = x9 y9
 
+      f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
+
+      f1 :: forall s m a b. (Functor s, Applicative m) => m (Either (s (Coroutine s m (a -> b))) (a -> b)) -> Coroutine s m a -> m (Either (s (Coroutine s m b)) b)
+
+      f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Coroutine s m a -> Either (s (Coroutine s m b)) b
+
+      f2a0 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
+
+      f2a1 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
+      
+      f2b0 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> Coroutine s m a -> 
+
   type Snapshot = String
 
   data CompilerErrors a = CompilerErrors

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -24,19 +24,18 @@ module Hexyll.Core.Compiler where
       -- See https://github.com/ekmett/free/blob/7be30d7cd139a7f40a5e76cd3cb126534c239231/src/Control/Monad/Free.hs#L219-L225 .
       -- That is the implementation of 'Functor f => Applicative (Free f)' in free-5.1.3. This implementation is based on it.
       f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
-      f0 (Coroutine x0) (Coroutine y0) = Coroutine (f2 <$> x0 <*> y0)
+      f0 x0 y0 = Coroutine (f2 <$> unCoroutine x0 <*> unCoroutine y0)
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b
-      f2 (Left x2     )  y2            = Left (f3 x2 (Coroutine (pure y2)))
-      f2 (Right x2    ) (Left y2     ) = Left (fmap (fmap x2) y2)
-      f2 (Right x2    ) (Right y2    ) = Right (x2 y2)
-      f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
-      f3  x3             y3            = fmap (\x' -> f0 x' y3) x3
+      f2 (Left x2 )  y2        = Left (fmap (flip f0 (Coroutine (pure y2))) x2)
+      f2 (Right x2) (Left y2 ) = Left (fmap (fmap x2) y2)
+      f2 (Right x2) (Right y2) = Right (x2 y2)
 
   instance (Functor s, Monad m) => Monad (Coroutine s m) where
     x >>= y = f0 x y where
-      f0 (Coroutine x0) y0 = Coroutine (f1 x0 y0)
-      f1 x1 y1 = x1 >>= \x' -> f2 x' y1
-      f2 (Left x2) y2 = pure (Left (fmap (\x' -> f0 x' y2) x2))
+      f0 :: forall s m a b. (Functor s, Monad m) => Coroutine s m a -> (a -> Coroutine s m b) -> Coroutine s m b
+      f0 x0 y0 = Coroutine (unCoroutine x0 >>= flip f2 y0)
+      f2 :: forall s m a b. (Functor s, Monad m) => Either (s (Coroutine s m a)) a -> (a -> Coroutine s m b) -> m (Either (s (Coroutine s m b)) b)
+      f2 (Left x2)  y2 = pure (Left (fmap (flip f0 y2) x2))
       f2 (Right x2) y2 = unCoroutine (y2 x2)
 
   type Snapshot = String

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -85,7 +85,7 @@ module Hexyll.Core.Compiler where
 
   instance HasProviderEnv CompilerRead where
     providerEnvL =
-      lens compilerProviderEnv (\env prov -> env { compilerProviderEnv = prov })
+      lens compilerProviderEnv (\env prv -> env { compilerProviderEnv = prv })
 
   instance HasStoreEnv CompilerRead where
     storeEnvL = providerEnvL . storeEnvL
@@ -96,7 +96,7 @@ module Hexyll.Core.Compiler where
 
   instance HasLogEnv CompilerRead where
     logEnvL =
-      lens compilerLogEnv (\env logEnv -> env { compilerLogEnv = logEnv })
+      lens compilerLogEnv (\env lge -> env { compilerLogEnv = lge })
 
   data CompilerWrite = CompilerWrite
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -1,0 +1,26 @@
+module Hexyll.Core.Compiler where
+
+  import Prelude
+
+  import Control.Monad.Trans.RWS.Strict ( RWST (..) )
+  import Control.Monad.Coroutine        ( Coroutine (..) )
+
+  import Hexyll.Core.Identifier
+
+  type Snapshot = String
+
+  data CompilerErrors a = CompilerErrors
+
+  data CompilerSuspend a
+    = CompilerSnapshot Snapshot a
+    | CompilerRequire Identifier Snapshot a
+    | CompilerError (CompilerErrors String)
+
+  data CompilerRead = CompilerRead
+
+  data CompilerWrite = CompilerWrite
+
+  newtype Compiler a = Compiler
+    { unCompiler
+      :: RWST CompilerRead CompilerWrite () (Coroutine CompilerSuspend IO) a
+    }

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -3,9 +3,12 @@ module Hexyll.Core.Compiler where
   import Prelude
 
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
-  import Control.Monad.Coroutine        ( Coroutine (..) )
 
   import Hexyll.Core.Identifier
+
+  newtype Coroutine s m a = Coroutine
+    { unCoroutine :: m (Either (s (Coroutine s m r)) r)
+    }
 
   type Snapshot = String
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -22,8 +22,7 @@ module Hexyll.Core.Compiler where
     pure x = Coroutine (pure (Right x))
     x <*> y = f0 x y where
       -- See https://github.com/ekmett/free/blob/7be30d7cd139a7f40a5e76cd3cb126534c239231/src/Control/Monad/Free.hs#L219-L225 .
-      -- That is the implementation of 'Functor f => Applicative (Free f)' in free-5.1.3.
-      -- This implementation is based on it.
+      -- That is the implementation of 'Functor f => Applicative (Free f)' in free-5.1.3. This implementation is based on it.
       f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
       f0 (Coroutine x0) (Coroutine y0) = Coroutine (f2 <$> x0 <*> y0)
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -46,18 +46,6 @@ module Hexyll.Core.Compiler where
       f9 :: forall a b. (a -> b) -> a -> b
       f9  x9             y9            = x9 y9
 
-      f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
-
-      f1 :: forall s m a b. (Functor s, Applicative m) => m (Either (s (Coroutine s m (a -> b))) (a -> b)) -> Coroutine s m a -> m (Either (s (Coroutine s m b)) b)
-
-      f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Coroutine s m a -> Either (s (Coroutine s m b)) b
-
-      f2a0 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
-
-      f2a1 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
-      
-      f2b0 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> Coroutine s m a -> 
-
   type Snapshot = String
 
   data CompilerErrors a = CompilerErrors

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -18,6 +18,7 @@ module Hexyll.Core.Compiler where
   import Hexyll.Core.LogEnv
   import Hexyll.Core.StoreEnv
   import Hexyll.Core.ProviderEnv
+  import Hexyll.Core.UniverseEnv
 
   newtype Coroutine s m a = Coroutine
     { unCoroutine :: m (Either (s (Coroutine s m a)) a)
@@ -73,7 +74,7 @@ module Hexyll.Core.Compiler where
     { compilerConfig :: Configuration
     , compilerUnderlying :: Identifier
     , compilerProviderEnv :: ProviderEnv
-    , compilerUniverseEnv :: S.Set Identifier
+    , compilerUniverseEnv :: UniverseEnv
     , compilerRoutes :: Routes
     , compilerLogEnv :: LogEnv
     }
@@ -88,6 +89,10 @@ module Hexyll.Core.Compiler where
 
   instance HasStoreEnv CompilerRead where
     storeEnvL = providerEnvL . storeEnvL
+
+  instance HasUniverseEnv CompilerRead where
+    universeEnvL =
+      lens compilerUniverseEnv (\env uni -> env { compilerUniverseEnv = uni })
 
   instance HasLogEnv CompilerRead where
     logEnvL =

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ExplicitForAll #-}
+
 module Hexyll.Core.Compiler where
 
   import Prelude
@@ -17,6 +19,23 @@ module Hexyll.Core.Compiler where
       f2 (Left s     ) = Left (f3 s)
       f2 (Right x    ) = Right (f x)
       f3  x            = fmap f0 x
+
+  instance (Functor s, Applicative m) => Applicative (Coroutine s m) where
+    pure x = Coroutine (pure (Right x))
+    x <*> y = f0 x y where
+      f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
+      f0 (Coroutine x0) (Coroutine y0) = Coroutine (f1 x0 y0)
+      f1 :: forall s m a b. (Functor s, Applicative m) => m (Either (s (Coroutine s m (a -> b))) (a -> b)) -> m (Either (s (Coroutine s m a)) a) -> m (Either (s (Coroutine s m b)) b)
+      f1  x1             y1            = f2 <$> x1 <*> y1
+      f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b
+      f2 (Left x2     )  y2            = Left (f3 x2 y2)
+      f2 (Right x2    )  y2            = undefined
+      f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Either (s (Coroutine s m a)) a -> s (Coroutine s m b)
+      f3  x3             y3            = f4 x3 (pure y3)
+      f4 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> m (Either (s (Coroutine s m a)) a) -> s (Coroutine s m b)
+      f4  x4             y4            = f5 x4 (Coroutine y4)
+      f5 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
+      f5  x5             y5            = fmap (<*> y5) x5
 
   type Snapshot = String
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -10,6 +10,14 @@ module Hexyll.Core.Compiler where
     { unCoroutine :: m (Either (s (Coroutine s m a)) a)
     }
 
+  instance (Functor s, Functor m) => Functor (Coroutine s m) where
+    fmap f = f0 where
+      f0 (Coroutine x) = Coroutine (f1 x)
+      f1  x            = fmap f2 x
+      f2 (Left s     ) = Left (f3 s)
+      f2 (Right x    ) = Right (f x)
+      f3  x            = fmap f0 x
+
   type Snapshot = String
 
   data CompilerErrors a = CompilerErrors

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -14,37 +14,21 @@ module Hexyll.Core.Compiler where
 
   instance (Functor s, Functor m) => Functor (Coroutine s m) where
     fmap f = f0 where
-      f0 (Coroutine x) = Coroutine (f1 x)
-      f1  x            = fmap f2 x
-      f2 (Left s     ) = Left (f3 s)
+      f0 (Coroutine x) = Coroutine (fmap f2 x)
+      f2 (Left x     ) = Left (fmap f0 x)
       f2 (Right x    ) = Right (f x)
-      f3  x            = fmap f0 x
 
   instance (Functor s, Applicative m) => Applicative (Coroutine s m) where
     pure x = Coroutine (pure (Right x))
     x <*> y = f0 x y where
       f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
-      f0 (Coroutine x0) (Coroutine y0) = Coroutine (f1 x0 y0)
-      f1 :: forall s m a b. (Functor s, Applicative m) => m (Either (s (Coroutine s m (a -> b))) (a -> b)) -> m (Either (s (Coroutine s m a)) a) -> m (Either (s (Coroutine s m b)) b)
-      f1  x1             y1            = f2 <$> x1 <*> y1
+      f0 (Coroutine x0) (Coroutine y0) = Coroutine (f2 <$> x0 <*> y0)
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b
-      f2 (Left x2     )  y2            = Left (f3 x2 y2)
-      f2 (Right x2    ) (Left y2     ) = Left (f7 x2 y2)
-      f2 (Right x2    ) (Right y2    ) = Right (f9 x2 y2)
-      f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Either (s (Coroutine s m a)) a -> s (Coroutine s m b)
-      f3  x3             y3            = f4 x3 (pure y3)
-      f4 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> m (Either (s (Coroutine s m a)) a) -> s (Coroutine s m b)
-      f4  x4             y4            = f5 x4 (Coroutine y4)
-      f5 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
-      f5  x5             y5            = fmap (\x' -> f6 x' y5) x5
-      f6 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
-      f6  x6             y6            = f0 x6 y6
-      f7 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> s (Coroutine s m a) -> s (Coroutine s m b)
-      f7  x7             y7            = fmap (f8 x7) y7
-      f8 :: forall s m a b. (Functor s, Applicative m) => (a -> b) -> Coroutine s m a -> Coroutine s m b
-      f8  x8             y8            = fmap x8 y8
-      f9 :: forall a b. (a -> b) -> a -> b
-      f9  x9             y9            = x9 y9
+      f2 (Left x2     )  y2            = Left (f3 x2 (Coroutine (pure y2)))
+      f2 (Right x2    ) (Left y2     ) = Left (fmap (fmap x2) y2)
+      f2 (Right x2    ) (Right y2    ) = Right (x2 y2)
+      f3 :: forall s m a b. (Functor s, Applicative m) => s (Coroutine s m (a -> b)) -> Coroutine s m a -> s (Coroutine s m b)
+      f3  x3             y3            = fmap (\x' -> f0 x' y3) x3
 
   type Snapshot = String
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -8,6 +8,8 @@ module Hexyll.Core.Compiler where
   import Control.Monad.Trans.Class      ( MonadTrans (..) )
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
 
+  import Lens.Micro        ( lens )
+
   import qualified Data.Set as S
 
   import Hexyll.Core.Configuration
@@ -75,6 +77,21 @@ module Hexyll.Core.Compiler where
     , compilerRoutes :: Routes
     , compilerLogEnv :: LogEnv
     }
+
+  instance HasConfiguration CompilerRead where
+    configurationL =
+      lens compilerConfig (\env config -> env { compilerConfig = config })
+
+  instance HasProviderEnv CompilerRead where
+    providerEnvL =
+      lens compilerProviderEnv (\env prov -> env { compilerProviderEnv = prov })
+
+  instance HasStoreEnv CompilerRead where
+    storeEnvL = providerEnvL . storeEnvL
+
+  instance HasLogEnv CompilerRead where
+    logEnvL =
+      lens compilerLogEnv (\env logEnv -> env { compilerLogEnv = logEnv })
 
   data CompilerWrite = CompilerWrite
 

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -21,6 +21,9 @@ module Hexyll.Core.Compiler where
   instance (Functor s, Applicative m) => Applicative (Coroutine s m) where
     pure x = Coroutine (pure (Right x))
     x <*> y = f0 x y where
+      -- See https://github.com/ekmett/free/blob/7be30d7cd139a7f40a5e76cd3cb126534c239231/src/Control/Monad/Free.hs#L219-L225 .
+      -- That is the implementation of 'Functor f => Applicative (Free f)' in free-5.1.3.
+      -- This implementation is based on it.
       f0 :: forall s m a b. (Functor s, Applicative m) => Coroutine s m (a -> b) -> Coroutine s m a -> Coroutine s m b
       f0 (Coroutine x0) (Coroutine y0) = Coroutine (f2 <$> x0 <*> y0)
       f2 :: forall s m a b. (Functor s, Applicative m) => Either (s (Coroutine s m (a -> b))) (a -> b) -> Either (s (Coroutine s m a)) a -> Either (s (Coroutine s m b)) b

--- a/hexyll-core/src/Hexyll/Core/Compiler.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler.hs
@@ -8,7 +8,14 @@ module Hexyll.Core.Compiler where
   import Control.Monad.Trans.Class      ( MonadTrans (..) )
   import Control.Monad.Trans.RWS.Strict ( RWST (..) )
 
+  import qualified Data.Set as S
+
+  import Hexyll.Core.Configuration
   import Hexyll.Core.Identifier
+  import Hexyll.Core.Routes
+  import Hexyll.Core.LogEnv
+  import Hexyll.Core.StoreEnv
+  import Hexyll.Core.ProviderEnv
 
   newtype Coroutine s m a = Coroutine
     { unCoroutine :: m (Either (s (Coroutine s m a)) a)
@@ -61,6 +68,13 @@ module Hexyll.Core.Compiler where
     fmap f (CompilerError e) = CompilerError e
 
   data CompilerRead = CompilerRead
+    { compilerConfig :: Configuration
+    , compilerUnderlying :: Identifier
+    , compilerProviderEnv :: ProviderEnv
+    , compilerUniverseEnv :: S.Set Identifier
+    , compilerRoutes :: Routes
+    , compilerLogEnv :: LogEnv
+    }
 
   data CompilerWrite = CompilerWrite
 

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -1,6 +1,20 @@
+{-# OPTIONS_HADDOCK not-home #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
+-- |
+-- Module:      Hexyll.Core.Compiler.Internal
+-- Copyright:   (c) 2019 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   internal
+-- Portability: non-portable (GHC extensions: multi-parameter type classes)
+--
+-- This is an internal module for "Hexyll.Core.Compiler".
+--
+-- @since 0.1.0.0
 module Hexyll.Core.Compiler.Internal where
 
   import Prelude

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -10,7 +10,7 @@
 -- License:     Apache-2.0
 -- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
 -- Stability:   internal
--- Portability: non-portable (GHC extensions: multi-parameter type classes)
+-- Portability: non-portable (multi-parameter type classes)
 --
 -- This is an internal module for "Hexyll.Core.Compiler".
 --

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -19,14 +19,16 @@ module Hexyll.Core.Compiler.Internal where
 
   import Prelude
 
-  import Control.Monad.IO.Class         ( MonadIO (..) )
-  import Control.Monad.Trans.Class      ( MonadTrans (..) )
-  import Control.Monad.Trans.RWS.Strict ( RWST (..) )
-  import Control.Monad.Reader.Class     ( MonadReader (..) )
+  import Control.Monad.IO.Class     ( MonadIO (..) )
+  import Control.Monad.Trans.Class  ( MonadTrans (..) )
+  import Control.Monad.Trans.Reader ( ReaderT (..) )
+  import Control.Monad.Reader.Class ( MonadReader (..) )
 
   import Lens.Micro        ( lens )
 
   import qualified Data.Set as S
+
+  import Data.IORef ( IORef )
 
   import Hexyll.Core.Configuration
   import Hexyll.Core.Identifier
@@ -106,6 +108,7 @@ module Hexyll.Core.Compiler.Internal where
     , compilerUniverseEnv :: UniverseEnv
     , compilerRoutes :: Routes
     , compilerLogEnv :: LogEnv
+    , compilerWrite :: IORef CompilerWrite
     }
 
   instance HasConfiguration CompilerRead where
@@ -141,7 +144,7 @@ module Hexyll.Core.Compiler.Internal where
 
   newtype Compiler a = Compiler
     { unCompiler
-      :: RWST CompilerRead CompilerWrite () (Coroutine CompilerSuspend IO) a
+      :: ReaderT CompilerRead (Coroutine CompilerSuspend IO) a
     }
 
   instance Functor Compiler where

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -102,13 +102,13 @@ module Hexyll.Core.Compiler.Internal where
     fmap f (CompilerError e) = CompilerError e
 
   data CompilerRead = CompilerRead
-    { compilerConfig :: Configuration
-    , compilerUnderlying :: Identifier
-    , compilerProviderEnv :: ProviderEnv
-    , compilerUniverseEnv :: UniverseEnv
-    , compilerRoutes :: Routes
-    , compilerLogEnv :: LogEnv
-    , compilerWrite :: IORef CompilerWrite
+    { compilerConfig :: !Configuration
+    , compilerUnderlying :: !Identifier
+    , compilerProviderEnv :: !ProviderEnv
+    , compilerUniverseEnv :: !UniverseEnv
+    , compilerRoutes :: !Routes
+    , compilerLogEnv :: !LogEnv
+    , compilerWrite :: !(IORef CompilerWrite)
     }
 
   instance HasConfiguration CompilerRead where
@@ -131,8 +131,8 @@ module Hexyll.Core.Compiler.Internal where
       lens compilerLogEnv (\env lge -> env { compilerLogEnv = lge })
 
   data CompilerWrite = CompilerWrite
-    { compilerDependencies :: S.Set Dependency
-    , compilerCache :: S.Set Identifier
+    { compilerDependencies :: !(S.Set Dependency)
+    , compilerCache :: !(S.Set Identifier)
     }
 
   instance Semigroup CompilerWrite where

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -31,9 +31,13 @@ module Hexyll.Core.Compiler.Internal where
   import Hexyll.Core.Configuration
   import Hexyll.Core.Identifier
   import Hexyll.Core.Routes
+  import Hexyll.Core.Log
   import Hexyll.Core.LogEnv
+  import Hexyll.Core.Store
   import Hexyll.Core.StoreEnv
+  import Hexyll.Core.Provider
   import Hexyll.Core.ProviderEnv
+  import Hexyll.Core.Universe
   import Hexyll.Core.UniverseEnv
 
   -- | Coroutine monad. This monad can be suspended and resumed.
@@ -151,3 +155,20 @@ module Hexyll.Core.Compiler.Internal where
   instance MonadReader CompilerRead Compiler where
     ask = Compiler ask
     local f (Compiler x) = Compiler (local f x)
+
+  instance MonadLog Compiler where
+    logGeneric = logGenericE
+
+  instance MonadStore Compiler where
+    save = saveE
+    loadDelay = loadDelayE
+
+  instance MonadProvider Compiler where
+    getAllPath = getAllPathE
+    getMTimeDelay = getMTimeDelayE
+    getBodyDelay = getBodyDelayE
+
+  instance MonadUniverse Compiler where
+    getMatches = getMatchesE
+    getAllIdentifier = getAllIdentifierE
+    countUniverse = countUniverseE

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -31,6 +31,7 @@ module Hexyll.Core.Compiler.Internal where
   import Hexyll.Core.Configuration
   import Hexyll.Core.Identifier
   import Hexyll.Core.Routes
+  import Hexyll.Core.Dependencies
   import Hexyll.Core.Log
   import Hexyll.Core.LogEnv
   import Hexyll.Core.Store
@@ -127,12 +128,16 @@ module Hexyll.Core.Compiler.Internal where
       lens compilerLogEnv (\env lge -> env { compilerLogEnv = lge })
 
   data CompilerWrite = CompilerWrite
+    { compilerDependencies :: S.Set Dependency
+    , compilerCache :: S.Set Identifier
+    }
 
   instance Semigroup CompilerWrite where
-    CompilerWrite <> CompilerWrite = CompilerWrite
+    CompilerWrite d0 c0 <> CompilerWrite d1 c1 =
+      CompilerWrite (d0 <> d1) (c0 <> c1)
 
   instance Monoid CompilerWrite where
-    mempty = CompilerWrite
+    mempty = CompilerWrite mempty mempty
 
   newtype Compiler a = Compiler
     { unCompiler

--- a/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Compiler/Internal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-module Hexyll.Core.Compiler where
+module Hexyll.Core.Compiler.Internal where
 
   import Prelude
 

--- a/hexyll-core/src/Hexyll/Core/Configuration.hs
+++ b/hexyll-core/src/Hexyll/Core/Configuration.hs
@@ -14,6 +14,8 @@
 -- @since 0.1.0.0
 module Hexyll.Core.Configuration
   ( Configuration (..)
+  , HasConfiguration (..)
+  , askConfiguration
   , defaultConfiguration
   , defaultIgnoreFile
   , shouldIgnoreFile
@@ -21,14 +23,20 @@ module Hexyll.Core.Configuration
 
   import Prelude
 
+  import Control.Monad.IO.Class     ( MonadIO )
+  import Control.Monad.Reader.Class ( MonadReader ( ask ) )
+
+  import Lens.Micro        ( Lens' )
+  import Lens.Micro.Extras ( view )
+
   import Data.Default ( Default (..) )
 
   import Data.List ( isPrefixOf, isSuffixOf )
 
-  import Path
-
   import System.Exit    ( ExitCode )
   import System.Process ( system )
+
+  import Path
 
   -- | The top-level hexyll configration.
   --
@@ -72,6 +80,26 @@ module Hexyll.Core.Configuration
   -- | @since 0.1.0.0
   instance Default Configuration where
     def = defaultConfiguration
+
+  -- | Environment values with a configuration.
+  --
+  -- @since 0.1.0.0
+  class HasConfiguration env where
+    configurationL :: Lens' env Configuration
+
+  -- | @since 0.1.0.0
+  instance HasConfiguration Configuration where
+    configurationL = id
+
+  -- Ask the 'Configuration'.
+  --
+  -- @since 0.1.0.0
+  askConfiguration
+    :: (MonadIO m, MonadReader env m, HasConfiguration env)
+    => m Configuration
+  askConfiguration = do
+    env <- ask
+    return $ view configurationL env
 
 #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
   -- | Default configuration for a hexyll application.

--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -23,8 +23,8 @@ import           System.Random                 (randomIO)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Item
 import           Hexyll.Core.OldProvider

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -17,7 +17,7 @@ import           Prelude                       hiding (foldr)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 
 

--- a/hexyll-core/src/Hexyll/Core/OldCompiler.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler.hs
@@ -40,8 +40,8 @@ import           System.FilePath               (takeExtension)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
-import qualified Hexyll.Core.Compiler.Require  as Internal
+import           Hexyll.Core.OldCompiler.Internal
+import qualified Hexyll.Core.OldCompiler.Require  as Internal
 import           Hexyll.Core.Dependencies
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
@@ -125,7 +125,7 @@ getResourceWith reader = do
         then compilerUnsafeIO $ Item id' <$> reader provider id'
         else fail $ error' filePath
   where
-    error' fp = "Hexyll.Core.Compiler.getResourceWith: resource " ++
+    error' fp = "Hexyll.Core.OldCompiler.getResourceWith: resource " ++
         show fp ++ " not found"
 
 
@@ -176,11 +176,11 @@ cached name compiler = do
                       _              -> fail $ error' progName
   where
     error' progName =
-        "Hexyll.Core.Compiler.cached: Cache corrupt! " ++
+        "Hexyll.Core.OldCompiler.cached: Cache corrupt! " ++
          "Try running: " ++ progName ++ " clean"
 
     itDoesntEvenExist id' =
-        "Hexyll.Core.Compiler.cached: You are trying to (perhaps "    ++
+        "Hexyll.Core.OldCompiler.cached: You are trying to (perhaps "    ++
         "indirectly) use `cached` on a non-existing resource: there " ++
         "is no file backing " ++ show id'
 

--- a/hexyll-core/src/Hexyll/Core/OldCompiler.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler.hs
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-module Hexyll.Core.Compiler
+module Hexyll.Core.OldCompiler
     ( Compiler
     , getUnderlying
     , getUnderlyingExtension

--- a/hexyll-core/src/Hexyll/Core/OldCompiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler/Internal.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-module Hexyll.Core.Compiler.Internal
+module Hexyll.Core.OldCompiler.Internal
     ( -- * Types
       Snapshot
     , CompilerRead (..)

--- a/hexyll-core/src/Hexyll/Core/OldCompiler/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler/Internal.hs
@@ -205,7 +205,7 @@ instance MonadMetadata Compiler where
 
 --------------------------------------------------------------------------------
 -- | Compilation may fail with multiple error messages.
--- 'catchError' handles errors from 'throwError', 'fail' and 'Hexyll.Core.Compiler.noResult'
+-- 'catchError' handles errors from 'throwError', 'fail' and 'Hexyll.Core.OldCompiler.noResult'
 instance MonadError [String] Compiler where
     throwError = compilerThrow
     catchError c = compilerCatch c . (. compilerErrorMessages)
@@ -222,7 +222,7 @@ runCompiler compiler read' = handle handler $ unCompiler compiler read'
 
 --------------------------------------------------------------------------------
 -- | Trying alternative compilers if the first fails, regardless whether through
--- 'fail', 'throwError' or 'Hexyll.Core.Compiler.noResult'.
+-- 'fail', 'throwError' or 'Hexyll.Core.OldCompiler.noResult'.
 -- Aggregates error messages if all fail.
 instance Alternative Compiler where
     empty   = compilerNoResult []
@@ -237,7 +237,7 @@ instance Alternative Compiler where
           (CompilationNoResult xs, CompilationNoResult ys) -> compilerNoResult $ xs ++ ys
         ))
       where
-        debug = compilerDebugEntries "Hexyll.Core.Compiler.Internal: Alternative fail suppressed"
+        debug = compilerDebugEntries "Hexyll.Core.OldCompiler.Internal: Alternative fail suppressed"
     {-# INLINE (<|>) #-}
 
 
@@ -335,7 +335,7 @@ compilerDebugEntries msg = compilerDebugLog . (msg:) . map indent
 compilerTellDependenciesCache :: [Dependency] -> [Identifier] -> Compiler ()
 compilerTellDependenciesCache ds cs = do
   compilerDebugLog $ map (\d ->
-      "Hexyll.Core.Compiler.Internal: Adding dependency: " ++ show d) ds
+      "Hexyll.Core.OldCompiler.Internal: Adding dependency: " ++ show d) ds
   compilerTell mempty {compilerDependencies = ds, compilerCache = cs}
 {-# INLINE compilerTellDependenciesCache #-}
 

--- a/hexyll-core/src/Hexyll/Core/OldCompiler/Require.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler/Require.hs
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
-module Hexyll.Core.Compiler.Require
+module Hexyll.Core.OldCompiler.Require
     ( Snapshot
     , save
     , saveSnapshot

--- a/hexyll-core/src/Hexyll/Core/OldCompiler/Require.hs
+++ b/hexyll-core/src/Hexyll/Core/OldCompiler/Require.hs
@@ -20,7 +20,7 @@ import           Data.Typeable
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Dependencies
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.Pattern hiding ( Pattern, match )
@@ -72,12 +72,12 @@ loadSnapshot id' snapshot = do
             Store.Found x       -> return $ Item id' x
   where
     notFound =
-        "Hexyll.Core.Compiler.Require.load: " ++ show id' ++
+        "Hexyll.Core.OldCompiler.Require.load: " ++ show id' ++
         " (snapshot " ++ snapshot ++ ") was not found in the cache, " ++
         "the cache might be corrupted or " ++
         "the item you are referring to might not exist"
     wrongType e r =
-        "Hexyll.Core.Compiler.Require.load: " ++ show id' ++
+        "Hexyll.Core.OldCompiler.Require.load: " ++ show id' ++
         " (snapshot " ++ snapshot ++ ") was found in the cache, " ++
         "but does not have the right type: expected " ++ show e ++
         " but got " ++ show r
@@ -116,7 +116,7 @@ loadAllSnapshots (Pattern pattern) snapshot = do
 --------------------------------------------------------------------------------
 key :: Identifier -> String -> [String]
 key identifier snapshot =
-    ["Hexyll.Core.Compiler.Require", show identifier, snapshot]
+    ["Hexyll.Core.OldCompiler.Require", show identifier, snapshot]
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/ProviderEnv.hs
@@ -142,19 +142,20 @@ module Hexyll.Core.ProviderEnv
       tsn <- fmap M.fromList $ forM (S.toList ps) $ \p -> do
         t <- getModificationTime $ toFilePath $ unResource p
         return (p, t)
-      msl <- storeLoadDelay se newProviderEnv_key
-      tso <- case msl of
-        Nothing -> return M.empty
-        Just sl -> do
-          etso' <- runStoreLoad sl
-          case etso' of
-            Left e -> error $ "newProviderEnv: " ++ show e
-            Right tso' -> return $
-              let
-                coerce' :: M.Map Resource BinaryTime -> M.Map Resource UTCTime
-                coerce' = coerce
-              in
-                coerce' tso'
+      tso <- do
+        msl <- storeLoadDelay se newProviderEnv_key
+        case msl of
+          Nothing -> return M.empty
+          Just sl -> do
+            etso' <- runStoreLoad sl
+            case etso' of
+              Left e -> error $ "newProviderEnv: " ++ show e
+              Right tso' -> return $
+                let
+                  coerce' :: M.Map Resource BinaryTime -> M.Map Resource UTCTime
+                  coerce' = coerce
+                in
+                  coerce' tso'
       storeSave se newProviderEnv_key $ MkStoreValue $
         let
           coerce' :: M.Map Resource UTCTime -> M.Map Resource BinaryTime

--- a/hexyll-core/src/Hexyll/Core/Rules.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules.hs
@@ -49,7 +49,7 @@ import           Data.Typeable                  (Typeable)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal  hiding ( Pattern, match )
+import           Hexyll.Core.OldCompiler.Internal  hiding ( Pattern, match )
 import           Hexyll.Core.Dependencies
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.Pattern hiding ( Pattern, match )

--- a/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules/Internal.hs
@@ -22,7 +22,7 @@ import           Data.Set                       (Set)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal  hiding ( Pattern )
+import           Hexyll.Core.OldCompiler.Internal  hiding ( Pattern )
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.Pattern hiding ( Pattern )
 import           Hexyll.Core.Item.SomeItem

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -22,8 +22,8 @@ import           System.Exit                   (ExitCode (..))
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
-import           Hexyll.Core.Compiler.Require
+import           Hexyll.Core.OldCompiler.Internal
+import           Hexyll.Core.OldCompiler.Require
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Dependencies
 import           Hexyll.Core.Identifier hiding (toFilePath)

--- a/hexyll-core/src/Hexyll/Core/Universe.hs
+++ b/hexyll-core/src/Hexyll/Core/Universe.hs
@@ -43,10 +43,13 @@ module Hexyll.Core.Universe where
   -- @since 0.1.0.0
   class Monad m => MonadUniverse m where
 
+    {-# MINIMAL getMatches | getAllIdentifier #-}
+
     -- | Get identifiers that matches the pattern.
     --
     -- @since 0.1.0.0
     getMatches :: Pattern -> m (S.Set Identifier)
+    getMatches p = S.filter (`match` p) <$> getAllIdentifier
 
     -- | Get all identifiers.
     --

--- a/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/UniverseEnv.hs
@@ -61,20 +61,20 @@ module Hexyll.Core.UniverseEnv where
   -- | Get all identifiers.
   --
   -- @since 0.1.0.0
-  getAllIdentifier
+  getAllIdentifierE
     :: (MonadIO m, MonadReader env m, HasUniverseEnv env)
     => m (S.Set Identifier)
-  getAllIdentifier = do
+  getAllIdentifierE = do
     env <- ask
     liftIO $ universeAllIdent (view universeEnvL env)
 
   -- | Count the number of all identifiers.
   --
   -- @since 0.1.0.0
-  countUniverse
+  countUniverseE
     :: (MonadIO m, MonadReader env m, HasUniverseEnv env)
     => m Int
-  countUniverse = do
+  countUniverseE = do
     env <- ask
     liftIO $ universeCount (view universeEnvL env)
 

--- a/hexyll-core/src/Hexyll/Core/UnixFilter.hs
+++ b/hexyll-core/src/Hexyll/Core/UnixFilter.hs
@@ -22,7 +22,7 @@ import           System.IO               (Handle, hClose, hFlush, hGetContents,
 import           System.Process
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/unit-test/Hexyll/Core/RulesTest.hs
+++ b/hexyll-core/unit-test/Hexyll/Core/RulesTest.hs
@@ -9,7 +9,7 @@ module Hexyll.Core.RulesTest
 import           Data.IORef                     (IORef, newIORef, readIORef,
                                                  writeIORef)
 import qualified Data.Set                       as S
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.File
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.OldPattern

--- a/hexyll-core/unit-test/Hexyll/Core/UnixFilterTest.hs
+++ b/hexyll-core/unit-test/Hexyll/Core/UnixFilterTest.hs
@@ -12,7 +12,7 @@ import qualified Test.Tasty.HUnit       as H
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.UnixFilter

--- a/hexyll-core/unit-test/TestSuite/Util.hs
+++ b/hexyll-core/unit-test/TestSuite/Util.hs
@@ -23,7 +23,7 @@ import           Text.Printf                   (printf)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier
 import qualified Hexyll.Core.Logger            as Logger

--- a/hexyll-pandoc/src/Hexyll/Web/Pandoc.hs
+++ b/hexyll-pandoc/src/Hexyll/Web/Pandoc.hs
@@ -28,7 +28,7 @@ import           Text.Pandoc.Highlighting   (pygments)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Item
 import           Hexyll.Web.Pandoc.FileType
 

--- a/hexyll-pandoc/src/Hexyll/Web/Pandoc/Biblio.hs
+++ b/hexyll-pandoc/src/Hexyll/Web/Pandoc/Biblio.hs
@@ -26,8 +26,8 @@ module Hexyll.Web.Pandoc.Biblio
 import           Control.Monad            (liftM, replicateM)
 import           Data.Binary              (Binary (..))
 import           Data.Typeable            (Typeable)
-import           Hexyll.Core.Compiler
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.OldProvider

--- a/hexyll-pandoc/test/TestSuite/Util.hs
+++ b/hexyll-pandoc/test/TestSuite/Util.hs
@@ -27,7 +27,7 @@ import           Text.Printf                   (printf)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger

--- a/hexyll/src/Hexyll.hs
+++ b/hexyll/src/Hexyll.hs
@@ -2,7 +2,7 @@
 -- | Top-level module exporting all modules that are interesting for the user
 {-# LANGUAGE CPP #-}
 module Hexyll
-    ( module Hexyll.Core.Compiler
+    ( module Hexyll.Core.OldCompiler
     , module Hexyll.Core.Configuration
     , module Hexyll.Core.File
     , module Hexyll.Core.Identifier
@@ -30,7 +30,7 @@ module Hexyll
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.File
 import           Hexyll.Core.Identifier

--- a/hexyll/src/Hexyll/Web/CompressCss.hs
+++ b/hexyll/src/Hexyll/Web/CompressCss.hs
@@ -13,7 +13,7 @@ import           Data.List               (dropWhileEnd, isPrefixOf)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Item
 import           Hexyll.Core.Util.String
 

--- a/hexyll/src/Hexyll/Web/Feed.hs
+++ b/hexyll/src/Hexyll/Web/Feed.hs
@@ -29,7 +29,7 @@ module Hexyll.Web.Feed
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Item
 import           Hexyll.Core.Util.String     (replaceAll)
 import           Hexyll.Web.Template

--- a/hexyll/src/Hexyll/Web/Html/RelativizeUrls.hs
+++ b/hexyll/src/Hexyll/Web/Html/RelativizeUrls.hs
@@ -25,7 +25,7 @@ import           Data.List            (isPrefixOf)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Item
 import           Hexyll.Web.Html
 

--- a/hexyll/src/Hexyll/Web/Paginate.hs
+++ b/hexyll/src/Hexyll/Web/Paginate.hs
@@ -20,7 +20,7 @@ import qualified Data.Set                       as S
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.Pattern hiding ( Pattern )
 import           Hexyll.Core.Item

--- a/hexyll/src/Hexyll/Web/Redirect.hs
+++ b/hexyll/src/Hexyll/Web/Redirect.hs
@@ -10,7 +10,7 @@ import           Control.Applicative    ((<$>))
 import           Control.Monad          (forM_, when)
 import           Data.Binary            (Binary (..))
 import           Data.List              (sort, group)
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.OldRoutes
 import           Hexyll.Core.Rules

--- a/hexyll/src/Hexyll/Web/Tags.hs
+++ b/hexyll/src/Hexyll/Web/Tags.hs
@@ -82,7 +82,7 @@ import qualified Text.Blaze.Html5.Attributes     as A
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Dependencies
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Identifier.Pattern hiding ( Pattern, match )

--- a/hexyll/src/Hexyll/Web/Template/Context.hs
+++ b/hexyll/src/Hexyll/Web/Template/Context.hs
@@ -58,8 +58,8 @@ import           Data.Time.Clock               (UTCTime (..))
 import           Data.Time.Format              (formatTime)
 import qualified Data.Time.Format              as TF
 import           Data.Time.Locale.Compat       (TimeLocale, defaultTimeLocale)
-import           Hexyll.Core.Compiler
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.Metadata

--- a/hexyll/src/Hexyll/Web/Template/Internal.hs
+++ b/hexyll/src/Hexyll/Web/Template/Internal.hs
@@ -31,8 +31,8 @@ import           GHC.Generics                         (Generic)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.Writable

--- a/hexyll/src/Hexyll/Web/Template/List.hs
+++ b/hexyll/src/Hexyll/Web/Template/List.hs
@@ -26,7 +26,7 @@ import           Data.Time.Locale.Compat     (defaultTimeLocale)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.Metadata

--- a/hexyll/test/Hexyll/Web/Template/Context/Tests.hs
+++ b/hexyll/test/Hexyll/Web/Template/Context/Tests.hs
@@ -11,7 +11,7 @@ import           Test.Tasty.HUnit            (Assertion, testCase, (@=?))
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.OldProvider
 import           Hexyll.Core.OldStore           (Store)

--- a/hexyll/test/Hexyll/Web/Template/Tests.hs
+++ b/hexyll/test/Hexyll/Web/Template/Tests.hs
@@ -14,7 +14,7 @@ import           Test.Tasty.HUnit             (Assertion, assertBool, testCase,
 import           Data.Either                  (isLeft)
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler
+import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.OldProvider

--- a/hexyll/test/TestSuite/Util.hs
+++ b/hexyll/test/TestSuite/Util.hs
@@ -27,7 +27,7 @@ import           Text.Printf                   (printf)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.Compiler.Internal
+import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Configuration
 import           Hexyll.Core.Identifier hiding (toFilePath)
 import qualified Hexyll.Core.Logger            as Logger


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/85 .

Hexyll.Core.Compiler.Internal をリファクタリングする。具体的には Coroutine モナドを追加して Compiler モナドを ReaderT と Coroutine で実装した。しかし、より詳細の設計は旧来の設計の理解が足りないため決めることが出来ず、ドキュメントを書くことも出来なかった。それらは先送りして Hexyll.Core.Item などのリファクタリングを行い、その中で設計を固めていきたい。