### PR TITLE
Hexyll.Core.Item をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -17,7 +17,6 @@ import           Prelude                       hiding (foldr)
 
 
 --------------------------------------------------------------------------------
-import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 
 
@@ -54,10 +53,3 @@ itemSetBody :: a -> Item b -> Item a
 itemSetBody x (Item i _) = Item i x
 
 
---------------------------------------------------------------------------------
--- | Perform a compiler action on the item body. This is the same as 'traverse',
--- but looks less intimidating.
---
--- > withItemBody = traverse
-withItemBody :: (a -> Compiler b) -> Item a -> Compiler (Item b)
-withItemBody = traverse

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -1,3 +1,16 @@
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module:      Hexyll.Core.Item
+-- Copyright:   (c) 2020 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides other type which represents compilation results.
+--
+-- @since 0.1.0.0
 module Hexyll.Core.Item where
 
   import Prelude

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -5,7 +5,6 @@
 module Hexyll.Core.Item
     ( Item (..)
     , itemSetBody
-    , withItemBody
     ) where
 
 

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -1,54 +1,36 @@
---------------------------------------------------------------------------------
--- | An item is a combination of some content and its 'Identifier'. This way, we
--- can still use the 'Identifier' to access metadata.
-{-# LANGUAGE DeriveDataTypeable #-}
-module Hexyll.Core.Item
-    ( Item (..)
-    , itemSetBody
-    ) where
+module Hexyll.Core.Item where
 
+  import Prelude
 
---------------------------------------------------------------------------------
-import           Data.Binary                   (Binary (..))
-import           Data.Foldable                 (Foldable (..))
-import           Data.Typeable                 (Typeable)
-import           Prelude                       hiding (foldr)
+  import Data.Typeable ( Typeable )
 
+  import Data.Binary ( Binary (..) )
 
---------------------------------------------------------------------------------
-import           Hexyll.Core.Identifier
+  import Hexyll.Core.Identifier
 
+  -- | An item is a combination of some content and its 'Identifier'.
+  data Item a = Item
+    { itemIdentifier :: !Identifier
+    , itemBody       :: !a
+    } deriving (Eqm Ord, Show, Typeable)
 
---------------------------------------------------------------------------------
-data Item a = Item
-    { itemIdentifier :: Identifier
-    , itemBody       :: a
-    } deriving (Show, Typeable)
-
-
---------------------------------------------------------------------------------
-instance Functor Item where
+  instance Functor Item where
     fmap f (Item i x) = Item i (f x)
 
-
---------------------------------------------------------------------------------
-instance Foldable Item where
+  instance Foldable Item where
     foldr f z (Item _ x) = f x z
 
-
---------------------------------------------------------------------------------
-instance Traversable Item where
+  instance Traversable Item where
     traverse f (Item i x) = Item i <$> f x
 
+  instance Binary a => Binary (Item a) where
+    put (Item i x) = do
+      put i
+      put x
+    get = do
+      i <- get
+      x <- get
+      return $ Item i x
 
---------------------------------------------------------------------------------
-instance Binary a => Binary (Item a) where
-    put (Item i x) = put i >> put x
-    get            = Item <$> get <*> get
-
-
---------------------------------------------------------------------------------
-itemSetBody :: a -> Item b -> Item a
-itemSetBody x (Item i _) = Item i x
-
-
+  itemSetBody :: a -> Item b -> Item a
+  itemSetBody x (Item i _) = Item i x

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -40,5 +40,8 @@ module Hexyll.Core.Item where
       x <- get
       return $ Item i x
 
-  itemSetBody :: a -> Item b -> Item a
-  itemSetBody x (Item i _) = Item i x
+  -- | Set an item body.
+  --
+  -- @since 0.1.0.0
+  setItemBody :: a -> Item b -> Item a
+  setItemBody x (Item i _) = Item i x

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -12,7 +12,7 @@ module Hexyll.Core.Item where
   data Item a = Item
     { itemIdentifier :: !Identifier
     , itemBody       :: !a
-    } deriving (Eqm Ord, Show, Typeable)
+    } deriving (Eq, Ord, Show, Typeable)
 
   instance Functor Item where
     fmap f (Item i x) = Item i (f x)

--- a/hexyll-core/src/Hexyll/Core/Item.hs
+++ b/hexyll-core/src/Hexyll/Core/Item.hs
@@ -9,20 +9,28 @@ module Hexyll.Core.Item where
   import Hexyll.Core.Identifier
 
   -- | An item is a combination of some content and its 'Identifier'.
+  --
+  -- It's other type represents compilation results.
+  --
+  -- @since 0.1.0.0
   data Item a = Item
     { itemIdentifier :: !Identifier
     , itemBody       :: !a
     } deriving (Eq, Ord, Show, Typeable)
 
+  -- | @since 0.1.0.0
   instance Functor Item where
     fmap f (Item i x) = Item i (f x)
 
+  -- | @since 0.1.0.0
   instance Foldable Item where
     foldr f z (Item _ x) = f x z
 
+  -- | @since 0.1.0.0
   instance Traversable Item where
     traverse f (Item i x) = Item i <$> f x
 
+  -- | @since 0.1.0.0
   instance Binary a => Binary (Item a) where
     put (Item i x) = do
       put i

--- a/hexyll-pandoc/test/TestSuite/Util.hs
+++ b/hexyll-pandoc/test/TestSuite/Util.hs
@@ -123,7 +123,7 @@ cleanTestEnv = do
 -- | like 'Hexyll.Web.Pandoc.renderPandoc'
 -- | but allowing to test without the @usePandoc@ flag
 renderParagraphs :: Item String -> Compiler (Item String)
-renderParagraphs = withItemBody (return
+renderParagraphs = traverse (return
                        . intercalate "\n" -- no trailing line
                        . map (("<p>"++) . (++"</p>"))
                        . lines)

--- a/hexyll/src/Hexyll/Web/Template/Internal.hs
+++ b/hexyll/src/Hexyll/Web/Template/Internal.hs
@@ -95,7 +95,7 @@ templateBodyCompiler :: Compiler (Item Template)
 templateBodyCompiler = cached "Hexyll.Web.Template.templateBodyCompiler" $ do
     item <- getResourceBody
     file <- getUnderlying
-    withItemBody (compileTemplateFile file) item
+    traverse (compileTemplateFile file) item
 
 --------------------------------------------------------------------------------
 -- | Read complete file contents as a template
@@ -103,7 +103,7 @@ templateCompiler :: Compiler (Item Template)
 templateCompiler = cached "Hexyll.Web.Template.templateCompiler" $ do
     item <- getResourceString
     file <- getUnderlying
-    withItemBody (compileTemplateFile file) item
+    traverse (compileTemplateFile file) item
 
 
 --------------------------------------------------------------------------------

--- a/hexyll/src/Hexyll/Web/Template/Internal.hs
+++ b/hexyll/src/Hexyll/Web/Template/Internal.hs
@@ -114,7 +114,7 @@ applyTemplate :: Template                -- ^ Template
               -> Compiler (Item String)  -- ^ Resulting item
 applyTemplate tpl context item = do
     body <- applyTemplate' (tplElements tpl) context item `catchError` handler
-    return $ itemSetBody body item
+    return $ setItemBody body item
   where
     tplName = tplOrigin tpl
     itemName = show $ itemIdentifier item

--- a/hexyll/test/TestSuite/Util.hs
+++ b/hexyll/test/TestSuite/Util.hs
@@ -123,7 +123,7 @@ cleanTestEnv = do
 -- | like 'Hexyll.Web.Pandoc.renderPandoc'
 -- | but allowing to test without the @usePandoc@ flag
 renderParagraphs :: Item String -> Compiler (Item String)
-renderParagraphs = withItemBody (return
+renderParagraphs = traverse (return
                        . intercalate "\n" -- no trailing line
                        . map (("<p>"++) . (++"</p>"))
                        . lines)


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/133 .

Hexyll.Core.OldCompiler への依存をなくし、その他も私のスタイルの形に合わせた。