### PR TITLE
Hexyll.Core.Writable を書き換える。

### DIFF
--- a/hexyll-core/src/Hexyll/Core/File.hs
+++ b/hexyll-core/src/Hexyll/Core/File.hs
@@ -30,7 +30,7 @@ import           Hexyll.Core.Item
 import           Hexyll.Core.OldProvider
 import qualified Hexyll.Core.OldStore          as Store
 import           Hexyll.Core.Util.File
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Item/SomeItem.hs
+++ b/hexyll-core/src/Hexyll/Core/Item/SomeItem.hs
@@ -13,7 +13,7 @@ import           Data.Typeable        (Typeable)
 
 --------------------------------------------------------------------------------
 import           Hexyll.Core.Item
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/OldWritable.hs
+++ b/hexyll-core/src/Hexyll/Core/OldWritable.hs
@@ -2,7 +2,7 @@
 -- | Describes writable items; items that can be saved to the disk
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-module Hexyll.Core.Writable
+module Hexyll.Core.OldWritable
     ( Writable (..)
     ) where
 

--- a/hexyll-core/src/Hexyll/Core/Rules.hs
+++ b/hexyll-core/src/Hexyll/Core/Rules.hs
@@ -60,7 +60,7 @@ import qualified Hexyll.Core.Metadata as Meta   ( Pattern (..) )
 import           Hexyll.Core.OldRoutes             hiding ( Pattern, match )
 import qualified Hexyll.Core.OldRoutes as Route    ( Pattern (..) )
 import           Hexyll.Core.Rules.Internal
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Runtime.hs
+++ b/hexyll-core/src/Hexyll/Core/Runtime.hs
@@ -37,7 +37,7 @@ import           Hexyll.Core.Rules.Internal
 import           Hexyll.Core.OldStore             (Store)
 import qualified Hexyll.Core.OldStore             as Store
 import           Hexyll.Core.Util.File
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 
 
 --------------------------------------------------------------------------------

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -15,5 +15,7 @@ module Hexyll.Core.Writable where
 
   import Prelude
 
+  import System.IO (Handle)
+
   class Writable a where
     write :: Handle -> a -> IO ()

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -1,12 +1,14 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
 
+{-# LANGUAGE FlexibleInstances #-}
+
 -- |
 -- Module:      Hexyll.Core.Writable
 -- Copyright:   (c) 2020 Hexirp
 -- License:     Apache-2.0
 -- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
 -- Stability:   stable
--- Portability: portable
+-- Portability: non-portable (ghc-extensions: FlexibleInstances)
 --
 -- This module provides a type class 'Writable'.
 --

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -21,9 +21,9 @@ module Hexyll.Core.Writable where
 
   import System.IO (Handle, hPutStrLn)
 
-  import qualified Data.ByteString as BS         (hPut)
-  import qualified Data.ByteString.Lazy as BL    (hPut)
-  import qualified Data.ByteString.Builder as BB (hPutBuilder)
+  import qualified Data.ByteString as BS
+  import qualified Data.ByteString.Lazy as BL
+  import qualified Data.ByteString.Builder as BB
 
   class Writable a where
     write :: Handle -> a -> IO ()

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -1,0 +1,19 @@
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module:      Hexyll.Core.Writable
+-- Copyright:   (c) 2020 Hexirp
+-- License:     Apache-2.0
+-- Maintainer:  https://github.com/Hexirp/hexirp-hakyll
+-- Stability:   stable
+-- Portability: portable
+--
+-- This module provides a type class 'Writable'.
+--
+-- @since 0.1.0.0
+module Hexyll.Core.Writable where
+
+  import Prelude
+
+  class Writable a where
+    write :: Handle -> a -> IO ()

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -15,7 +15,13 @@ module Hexyll.Core.Writable where
 
   import Prelude
 
-  import System.IO (Handle)
+  import System.IO (Handle, hPutStrLn)
 
   class Writable a where
     write :: Handle -> a -> IO ()
+
+  instance Writable () where
+    write _ _ = return ()
+
+  instance Writable String where
+    write h s = hPutStrLn h s

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -25,23 +25,32 @@ module Hexyll.Core.Writable where
   import qualified Data.ByteString.Lazy as BL
   import qualified Data.ByteString.Builder as BB
 
+  -- | A type class for writable and printable types.
+  --
+  -- @since 0.1.0.0
   class Writable a where
     write :: Handle -> a -> IO ()
 
+  -- | @since 0.1.0.0
   instance Writable () where
     write _ _ = return ()
 
+  -- | @since 0.1.0.0
   instance Writable String where
     write h s = hPutStrLn h s
 
+  -- | @since 0.1.0.0
   instance Writable BS.ByteString where
     write h s = BS.hPut h s
 
+  -- | @since 0.1.0.0
   instance Writable BL.ByteString where
     write h s = BL.hPut h s
 
+  -- | @since 0.1.0.0
   instance Writable BB.Builder where
     write h s = BB.hPutBuilder h s
 
+  -- | @since 0.1.0.0
   instance Writable [Word8] where
     write h s = write h (foldMap BB.word8 s)

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -19,7 +19,7 @@ module Hexyll.Core.Writable where
 
   import Data.Word (Word8)
 
-  import System.IO (Handle, hPutStrLn)
+  import System.IO (Handle, hPutStr)
 
   import qualified Data.ByteString as BS
   import qualified Data.ByteString.Lazy as BL
@@ -29,6 +29,11 @@ module Hexyll.Core.Writable where
   --
   -- @since 0.1.0.0
   class Writable a where
+    -- | Write a value.
+    --
+    -- It is implemented by 'hPutStr', 'BS.hPut', etc.
+    --
+    -- @since 0.1.0.0
     write :: Handle -> a -> IO ()
 
   -- | @since 0.1.0.0
@@ -37,7 +42,7 @@ module Hexyll.Core.Writable where
 
   -- | @since 0.1.0.0
   instance Writable String where
-    write h s = hPutStrLn h s
+    write h s = hPutStr h s
 
   -- | @since 0.1.0.0
   instance Writable BS.ByteString where

--- a/hexyll-core/src/Hexyll/Core/Writable.hs
+++ b/hexyll-core/src/Hexyll/Core/Writable.hs
@@ -17,7 +17,13 @@ module Hexyll.Core.Writable where
 
   import Prelude
 
+  import Data.Word (Word8)
+
   import System.IO (Handle, hPutStrLn)
+
+  import qualified Data.ByteString as BS         (hPut)
+  import qualified Data.ByteString.Lazy as BL    (hPut)
+  import qualified Data.ByteString.Builder as BB (hPutBuilder)
 
   class Writable a where
     write :: Handle -> a -> IO ()
@@ -27,3 +33,15 @@ module Hexyll.Core.Writable where
 
   instance Writable String where
     write h s = hPutStrLn h s
+
+  instance Writable BS.ByteString where
+    write h s = BS.hPut h s
+
+  instance Writable BL.ByteString where
+    write h s = BL.hPut h s
+
+  instance Writable BB.Builder where
+    write h s = BB.hPutBuilder h s
+
+  instance Writable [Word8] where
+    write h s = write h (foldMap BB.word8 s)

--- a/hexyll-pandoc/src/Hexyll/Web/Pandoc/Biblio.hs
+++ b/hexyll-pandoc/src/Hexyll/Web/Pandoc/Biblio.hs
@@ -31,7 +31,7 @@ import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
 import           Hexyll.Core.OldProvider
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 import           Hexyll.Web.Pandoc
 import           Hexyll.Web.Pandoc.Binary ()
 import qualified Text.CSL                 as CSL

--- a/hexyll/src/Hexyll.hs
+++ b/hexyll/src/Hexyll.hs
@@ -14,7 +14,7 @@ module Hexyll
     , module Hexyll.Core.UnixFilter
     , module Hexyll.Core.Util.File
     , module Hexyll.Core.Util.String
-    , module Hexyll.Core.Writable
+    , module Hexyll.Core.OldWritable
     , module Hexyll.Main
     , module Hexyll.Web.CompressCss
     , module Hexyll.Web.Feed
@@ -42,7 +42,7 @@ import           Hexyll.Core.Rules
 import           Hexyll.Core.UnixFilter
 import           Hexyll.Core.Util.File
 import           Hexyll.Core.Util.String
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 import           Hexyll.Main
 import           Hexyll.Web.CompressCss
 import           Hexyll.Web.Feed

--- a/hexyll/src/Hexyll/Web/Redirect.hs
+++ b/hexyll/src/Hexyll/Web/Redirect.hs
@@ -14,7 +14,7 @@ import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.OldRoutes
 import           Hexyll.Core.Rules
-import           Hexyll.Core.Writable   (Writable (..))
+import           Hexyll.Core.OldWritable   (Writable (..))
 
 -- | This function exposes a higher-level interface compared to using the
 -- 'Redirect' type manually.

--- a/hexyll/src/Hexyll/Web/Template/Internal.hs
+++ b/hexyll/src/Hexyll/Web/Template/Internal.hs
@@ -35,7 +35,7 @@ import           Hexyll.Core.OldCompiler
 import           Hexyll.Core.OldCompiler.Internal
 import           Hexyll.Core.Identifier
 import           Hexyll.Core.Item
-import           Hexyll.Core.Writable
+import           Hexyll.Core.OldWritable
 import           Hexyll.Web.Template.Context
 import           Hexyll.Web.Template.Internal.Element
 import           Hexyll.Web.Template.Internal.Trim


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/145 .

Hexyll.Core.Writable を書き換える。

出力先を Handle へ一般化する。そして、見たところ Item として Identifier の情報が含まれている必要性は全くないので Item を使わない。あとで `Writable a => Item a -> Routes -> IO ()` みたいな関数を追加すればいいだろう。これによって Hexyll.Core.Item と Hexyll.Core.Item.SomeItem を統合できるようになる。