### PR TITLE
Hexyll.Core.Log をリファクタリングする

### DIFF
--- a/hexyll-core/src/Hexyll/Core/LogEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/LogEnv.hs
@@ -101,3 +101,21 @@ module Hexyll.Core.LogEnv where
       , logIndentLevel = 0
       }
     }
+
+  -- | Increase the indent level. It increase the indent level by 2.
+  --
+  -- @since 0.1.0.0
+  increaseIndent :: LogOption -> LogOption
+  increaseIndent lo = lo { logIndentLevel = logIndentLevel lo + 2 }
+
+  -- | Set the log level.
+  --
+  -- @since 0.1.0.0
+  setLogLevel :: LogLevel -> LogOption -> LogOption
+  setLogLevel ll lo = lo { logMinLevel = ll }
+
+  -- | Set the log source.
+  --
+  -- @since 0.1.0.0
+  setLogSource :: String -> LogOption -> LogOption
+  setLogSource ls lo = lo { logSource = ls }

--- a/hexyll-core/src/Hexyll/Core/LogEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/LogEnv.hs
@@ -104,6 +104,14 @@ module Hexyll.Core.LogEnv where
 
   -- | Increase the indent level. It increase the indent level by 2.
   --
+  -- There is an example:
+  --
+  -- @
+  --   loadTemplate = local (increaseIndent . setSource "loadTemplate") $ do
+  --     foo
+  --     bar
+  -- @
+  --
   -- @since 0.1.0.0
   increaseIndent :: LogOption -> LogOption
   increaseIndent lo = lo { logIndentLevel = logIndentLevel lo + 2 }

--- a/hexyll-core/src/Hexyll/Core/LogEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/LogEnv.hs
@@ -24,7 +24,7 @@ module Hexyll.Core.LogEnv where
   import Control.Monad.Reader.Class ( MonadReader )
 
   import Lens.Micro        ( Lens' )
-  import Lens.Micro.Hexyll ( askView )
+  import Lens.Micro.Hexyll ( askView, localOver )
 
   import System.IO ( stdout )
 
@@ -135,4 +135,4 @@ module Hexyll.Core.LogEnv where
   localLogEnv
     :: (MonadReader env m, HasLogEnv env)
     => (LogEnv -> LogEnv) -> m a -> m a
-  localLogEnv f ma = local (over logEnvL f) ma
+  localLogEnv f ma = localOver logEnvL f ma

--- a/hexyll-core/src/Hexyll/Core/LogEnv.hs
+++ b/hexyll-core/src/Hexyll/Core/LogEnv.hs
@@ -127,3 +127,12 @@ module Hexyll.Core.LogEnv where
   -- @since 0.1.0.0
   setLogSource :: String -> LogOption -> LogOption
   setLogSource ls lo = lo { logSource = ls }
+
+  -- | Executes a computation in an environment which was modified over
+  -- 'logEnvL'.
+  --
+  -- @since 0.1.0.0
+  localLogEnv
+    :: (MonadReader env m, HasLogEnv env)
+    => (LogEnv -> LogEnv) -> m a -> m a
+  localLogEnv f ma = local (over logEnvL f) ma

--- a/hexyll-core/src/Lens/Micro/Hexyll.hs
+++ b/hexyll-core/src/Lens/Micro/Hexyll.hs
@@ -16,7 +16,7 @@ module Lens.Micro.Hexyll where
 
   import Prelude
 
-  import Control.Monad.Reader.Class (MonadReader (ask))
+  import Control.Monad.Reader.Class (MonadReader (ask, local))
 
   import Lens.Micro        (ASetter', over, Getting)
   import Lens.Micro.Extras (view)

--- a/hexyll-core/src/Lens/Micro/Hexyll.hs
+++ b/hexyll-core/src/Lens/Micro/Hexyll.hs
@@ -18,7 +18,7 @@ module Lens.Micro.Hexyll where
 
   import Control.Monad.Reader.Class (MonadReader (ask))
 
-  import Lens.Micro        (Getting)
+  import Lens.Micro        (ASetter', over, Getting)
   import Lens.Micro.Extras (view)
 
   -- | Ask the environment and apply a getter to it.
@@ -31,3 +31,12 @@ module Lens.Micro.Hexyll where
   askView l = do
     env <- ask
     return $ view l env
+
+  -- | Executes a computation in an environment which was modified over
+  -- a setter.
+  --
+  -- @since 0.1.0.0
+  localOver
+    :: MonadReader env m
+    => ASetter' env env' -> (env' -> env') -> m a -> m a
+  localOver l f ma = local (over l f) ma


### PR DESCRIPTION
Fix https://github.com/Hexirp/hexirp-hakyll/issues/147 .
Fix https://github.com/Hexirp/hexirp-hakyll/issues/103 .

`local` 関数と組み合わせて使える関数を用意した。また、 `LogEnv` 専用の `local` 関数も用意した。さらに、 `local` 関数と `over` 関数を組み合わせた `localOver` 関数を汎用関数として追加した。

`increaseIndent` については深さを自由に変更したりできるようにする方がいいかもしれない。